### PR TITLE
[FEAT] CI에서 사용할 testCoverageSonar gradle command 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,19 @@ jacocoTestReport {
 	finalizedBy jacocoTestCoverageVerification //verification은 report 이후에 시작해야함
 }
 
+task testCoverageSonar(type: Test){
+	group 'verification'
+	description 'Runs unit tests with coverage sonarCloud'
+	dependsOn(':test',
+			':jacocoTestReport',
+			':sonar',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['sonar'].mustRunAfter(tasks['jacocoTestReport'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['sonar'])
+}
+
 jacocoTestCoverageVerification {
 	dependsOn jacocoTestReport // jacocoTestReport 작업 이후에 실행되어야함
 	violationRules{


### PR DESCRIPTION
## PR 요약
CI 환경에서 사용할 testCoverageSonar gradle command를 구현해 추가했습니다.

커맨드는 test -> jacocoTestReport -> jacocoTestCoverageVerificaion 순으로 작동합니다.