### PR TITLE
[FEAT] OAuth2 로그인 구현

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run:
           name: build x test
-          command: gradle clean build -x test
+          command: gradle clean build -DincludeTags="docs"
       - run:
           name: set short sha
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,7 @@ jobs:
       - checkout
       - run:
           name: run build and test
-          command: gradle clean build -x test
-      - run:
-          name: run test coverage report sonarCloud
-          command: gradle testCoverageSonar
+          command: gradle clean build testCoverageSonar
       - slack/notify:
           event: fail
           template: basic_fail_1

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 application-localdb.yml
 application-local-security.yml
+
+src/main/resources/static/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application-localdb.yml
+application-local-security.yml

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -48,6 +49,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
@@ -56,18 +58,56 @@ dependencies {
     testImplementation 'org.testcontainers:mysql'
 }
 
-tasks.named('test') {
-    outputs.dir snippetsDir
-    useJUnitPlatform()
+
+asciidoctor {
+    dependsOn test
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
 }
 
-tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
-    dependsOn test
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }
 
 test {
-    finalizedBy jacocoTestReport // report는 항상 테스트가 끝난 후에 생성되어야함
+    outputs.dir snippetsDir
+    String includeTagsProperty = System.getProperty("includeTags")
+    boolean includeTagsPropertySet = includeTagsProperty != null
+
+    String excludeTagsProperty = System.getProperty("excludeTags")
+    boolean excludeTagsPropertySet = excludeTagsProperty != null
+
+    if (includeTagsPropertySet && excludeTagsPropertySet) {
+        useJUnitPlatform {
+            includeTags includeTagsProperty
+            excludeTags excludeTagsProperty
+        }
+    } else if (includeTagsPropertySet && !excludeTagsPropertySet) {
+        useJUnitPlatform {
+            includeTags includeTagsProperty
+        }
+    } else if (!includeTagsPropertySet && excludeTagsPropertySet) {
+        useJUnitPlatform {
+            excludeTags excludeTagsProperty
+        }
+    } else {
+        useJUnitPlatform()
+        finalizedBy jacocoTestReport // report는 항상 테스트가 끝난 후에 생성되어야함
+    }
 }
 
 sonar {
@@ -155,7 +195,6 @@ jib {
         tags = [System.getenv("SHORT_SHA")]
     }
 
-
     container {
         environment = [
                 "SPRING_PROFILES_ACTIVE": System.getenv("SPRING_PROFILES_ACTIVE"),
@@ -164,12 +203,12 @@ jib {
                 "datasource.password"   : System.getenv("DATASOURCE_PASSWORD"),
                 "CORS_ALLOW_ORIGINS"    : System.getenv("CORS_ALLOW_ORIGINS"),
                 "JWT_KEY"               : System.getenv("JWT_KEY"),
-                "GITHUB_CLIENT_ID" : System.getenv("GITHUB_CLIENT_ID"),
-                "GITHUB_CLIENT_SECRET" : System.getenv("GITHUB_CLIENT_SECRET"),
-                "KAKAO_CLIENT_ID" : System.getenv("KAKAO_CLIENT_ID"),
-                "KAKAO_CLIENT_SECRET" : System.getenv("KAKAO_CLIENT_SECRET"),
-                "GOOGLE_CLIENT_ID" : System.getenv("GOOGLE_CLIENT_ID"),
-                "GOOGLE_CLIENT_SECRET" : System.getenv("GOOGLE_CLIENT_SECRET"),
+                "GITHUB_CLIENT_ID"      : System.getenv("GITHUB_CLIENT_ID"),
+                "GITHUB_CLIENT_SECRET"  : System.getenv("GITHUB_CLIENT_SECRET"),
+                "KAKAO_CLIENT_ID"       : System.getenv("KAKAO_CLIENT_ID"),
+                "KAKAO_CLIENT_SECRET"   : System.getenv("KAKAO_CLIENT_SECRET"),
+                "GOOGLE_CLIENT_ID"      : System.getenv("GOOGLE_CLIENT_ID"),
+                "GOOGLE_CLIENT_SECRET"  : System.getenv("GOOGLE_CLIENT_SECRET"),
         ]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,6 @@ sonar {
         property 'sonar.projectKey', 'Recruitment-Platform_Socket-Backend'
         property 'sonar.organization', 'socket-recruitment-projec'
         property 'sonar.host.url', 'https://sonarcloud.io'
-        property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*'
         property 'sonar.test.exclusions', '**/*Application*.java'

--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+    // jwt 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -155,7 +161,15 @@ jib {
                 "SPRING_PROFILES_ACTIVE": System.getenv("SPRING_PROFILES_ACTIVE"),
                 "datasource.url"        : System.getenv("DATASOURCE_URL"),
                 "datasource.username"   : System.getenv("DATASOURCE_USERNAME"),
-                "datasource.password"   : System.getenv("DATASOURCE_PASSWORD")
+                "datasource.password"   : System.getenv("DATASOURCE_PASSWORD"),
+                "CORS_ALLOW_ORIGINS"    : System.getenv("CORS_ALLOW_ORIGINS"),
+                "JWT_KEY"               : System.getenv("JWT_KEY"),
+                "GITHUB_CLIENT_ID" : System.getenv("GITHUB_CLIENT_ID"),
+                "GITHUB_CLIENT_SECRET" : System.getenv("GITHUB_CLIENT_SECRET"),
+                "KAKAO_CLIENT_ID" : System.getenv("KAKAO_CLIENT_ID"),
+                "KAKAO_CLIENT_SECRET" : System.getenv("KAKAO_CLIENT_SECRET"),
+                "GOOGLE_CLIENT_ID" : System.getenv("GOOGLE_CLIENT_ID"),
+                "GOOGLE_CLIENT_SECRET" : System.getenv("GOOGLE_CLIENT_SECRET"),
         ]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -115,9 +115,11 @@ sonar {
         property 'sonar.projectKey', 'Recruitment-Platform_Socket-Backend'
         property 'sonar.organization', 'socket-recruitment-projec'
         property 'sonar.host.url', 'https://sonarcloud.io'
+        property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
+        property 'sonar.test.inclusions', '**/*Test.java'
+        property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*'
-        property 'sonar.test.exclusions', '**/*Application*.java'
     }
 }
 

--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -1,0 +1,30 @@
+[[kakao-login]]
+=== 카카오 로그인
+
+==== HTTP Request
+include::kakao-login/http-request.adoc[]
+
+==== HTTP Response
+include::kakao-login/http-response.adoc[]
+include::kakao-login/response-fields.adoc[]
+
+[[github-login]]
+=== 깃허브 로그인
+
+==== HTTP Request
+include::github-login/http-request.adoc[]
+
+==== HTTP Response
+include::github-login/http-response.adoc[]
+include::github-login/response-fields.adoc[]
+
+[[google-login]]
+=== 구글 로그인
+
+==== HTTP Request
+include::google-login/http-request.adoc[]
+
+==== HTTP Response
+include::google-login/http-response.adoc[]
+include::google-login/response-fields.adoc[]
+

--- a/src/docs/asciidoc/auth/github-login/http-request.adoc
+++ b/src/docs/asciidoc/auth/github-login/http-request.adoc
@@ -1,0 +1,6 @@
+[source.http.options="nowrap']
+----
+GET /oauth2/authorization/github HTTP/1.1
+Host: api.socketing.site
+
+----

--- a/src/docs/asciidoc/auth/github-login/http-response.adoc
+++ b/src/docs/asciidoc/auth/github-login/http-response.adoc
@@ -1,0 +1,11 @@
+[source.http.options="nowrap']
+----
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/github-login/response-body.adoc
+++ b/src/docs/asciidoc/auth/github-login/response-body.adoc
@@ -1,0 +1,8 @@
+[source,json,options="nowrap"]
+----
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/github-login/response-fields.adoc
+++ b/src/docs/asciidoc/auth/github-login/response-fields.adoc
@@ -1,0 +1,17 @@
+==== Response Fields
+|===
+|Path|Type|Description
+
+|`+profileSetup+`
+|`+boolean+`
+|프로필 설정 여부
+
+|`+accessToken+`
+|`+String+`
+|액세스 토큰
+
+|`+refreshToken+`
+|`+String+`
+|리프레쉬 토큰
+
+|===

--- a/src/docs/asciidoc/auth/google-login/http-request.adoc
+++ b/src/docs/asciidoc/auth/google-login/http-request.adoc
@@ -1,0 +1,6 @@
+[source.http.options="nowrap']
+----
+GET /oauth2/authorization/google HTTP/1.1
+Host: api.socketing.site
+
+----

--- a/src/docs/asciidoc/auth/google-login/http-response.adoc
+++ b/src/docs/asciidoc/auth/google-login/http-response.adoc
@@ -1,0 +1,11 @@
+[source.http.options="nowrap']
+----
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/google-login/response-body.adoc
+++ b/src/docs/asciidoc/auth/google-login/response-body.adoc
@@ -1,0 +1,8 @@
+[source,json,options="nowrap"]
+----
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/google-login/response-fields.adoc
+++ b/src/docs/asciidoc/auth/google-login/response-fields.adoc
@@ -1,0 +1,17 @@
+==== Response Fields
+|===
+|Path|Type|Description
+
+|`+profileSetup+`
+|`+boolean+`
+|프로필 설정 여부
+
+|`+accessToken+`
+|`+String+`
+|액세스 토큰
+
+|`+refreshToken+`
+|`+String+`
+|리프레쉬 토큰
+
+|===

--- a/src/docs/asciidoc/auth/kakao-login/http-request.adoc
+++ b/src/docs/asciidoc/auth/kakao-login/http-request.adoc
@@ -1,0 +1,6 @@
+[source.http.options="nowrap']
+----
+GET /oauth2/authorization/kakao HTTP/1.1
+Host: api.socketing.site
+
+----

--- a/src/docs/asciidoc/auth/kakao-login/http-response.adoc
+++ b/src/docs/asciidoc/auth/kakao-login/http-response.adoc
@@ -1,0 +1,11 @@
+[source.http.options="nowrap']
+----
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/kakao-login/response-body.adoc
+++ b/src/docs/asciidoc/auth/kakao-login/response-body.adoc
@@ -1,0 +1,8 @@
+[source,json,options="nowrap"]
+----
+{
+    "profileSetup": false,
+    "accessToken": "accessToken",
+    "refreshToken": "refreshToken"
+}
+----

--- a/src/docs/asciidoc/auth/kakao-login/response-fields.adoc
+++ b/src/docs/asciidoc/auth/kakao-login/response-fields.adoc
@@ -1,0 +1,17 @@
+==== Response Fields
+|===
+|Path|Type|Description
+
+|`+profileSetup+`
+|`+boolean+`
+|프로필 설정 여부
+
+|`+accessToken+`
+|`+String+`
+|액세스 토큰
+
+|`+refreshToken+`
+|`+String+`
+|리프레쉬 토큰
+
+|===

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,12 @@
+= SOCKET API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[AUTH-API]]
+== Auth API
+
+include::auth/auth.adoc[]

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.project.socket.common.error;
+
+public enum ErrorCode {
+
+  OAUTH2_LOGIN_FAIL(401, "A1", "로그인 실패"),
+  INVALID_JWT(401, "A2", "유효하지 않은 토큰입니다");
+
+  private int status;
+  private final String code;
+  private final String message;
+
+  ErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.message = message;
+    this.code = code;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
+++ b/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
@@ -1,0 +1,24 @@
+package com.project.socket.common.error;
+
+import java.net.URI;
+import org.springframework.http.ProblemDetail;
+
+public class ProblemDetailFactory {
+
+  private ProblemDetailFactory() {
+  }
+
+  public static ProblemDetail from(ErrorCode errorCode) {
+    ProblemDetail problemDetail = ProblemDetail
+        .forStatus(errorCode.getStatus());
+    problemDetail.setTitle(errorCode.getMessage());
+    problemDetail.setProperty("code", errorCode.getCode());
+    return problemDetail;
+  }
+
+  public static ProblemDetail of(ErrorCode errorCode, String instanceURI) {
+    ProblemDetail problemDetail = from(errorCode);
+    problemDetail.setInstance(URI.create(instanceURI));
+    return problemDetail;
+  }
+}

--- a/src/main/java/com/project/socket/common/model/BaseTime.java
+++ b/src/main/java/com/project/socket/common/model/BaseTime.java
@@ -1,0 +1,25 @@
+package com.project.socket.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+
+  @CreatedDate
+  @Column
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column
+  private LocalDateTime modifiedAt;
+}
+

--- a/src/main/java/com/project/socket/config/JpaConfig.java
+++ b/src/main/java/com/project/socket/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.project.socket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -1,26 +1,60 @@
 package com.project.socket.config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import com.project.socket.security.oauth2.handler.OAuth2LoginFailureHandler;
+import com.project.socket.security.oauth2.handler.OAuth2LoginSuccessHandler;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-  @Bean // HttpSecurity
+  private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+  @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
     http
+        .sessionManagement(sessionManager -> sessionManager
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .oauth2Login(oauth2Login -> oauth2Login
+            .successHandler(oAuth2LoginSuccessHandler)
+            .failureHandler(oAuth2LoginFailureHandler))
         .csrf(csrf -> csrf.disable())
+        .cors(withDefaults())
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(formLogin -> formLogin.disable())
-        .sessionManagement(sessionManagement ->
-            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
-            .anyRequest().permitAll());
+            .requestMatchers("/docs/**", "/actuator/**", "/", "/error/**").permitAll()
+            .anyRequest().authenticated());
     return http.build();
+  }
+
+  @Value("${cors.allow-origins}")
+  private List<String> corsOrigins;
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration corsConfiguration = new CorsConfiguration();
+    corsConfiguration.setAllowedOrigins(corsOrigins);
+    corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "DELETE", "PUT", "PATCH"));
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", corsConfiguration);
+    return source;
   }
 }

--- a/src/main/java/com/project/socket/security/JwtProvider.java
+++ b/src/main/java/com/project/socket/security/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.project.socket.security;
+
+import static com.project.socket.common.error.ErrorCode.INVALID_JWT;
+
+import com.project.socket.security.exception.InvalidJwtException;
+import com.project.socket.user.model.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+  private final String SECRET_KEY;
+  private static final String ISSUER = "SOCKET";
+  private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 6; //6시간
+  private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 14; //2주
+
+  public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+    this.SECRET_KEY = secretKey;
+  }
+
+  private Key getSigningKey() {
+    return Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public String createAccessToken(User user) {
+    Date now = new Date();
+    return Jwts.builder()
+               .setSubject(user.getUserId().toString())
+               .setIssuer(ISSUER)
+               .setIssuedAt(now)
+               .claim("role", user.getRole().toString())
+               .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME))
+               .signWith(getSigningKey(), SignatureAlgorithm.HS256).compact();
+  }
+
+  public String createRefreshToken(User user) {
+    Date now = new Date();
+    return Jwts.builder()
+               .setSubject(user.getUserId().toString())
+               .setIssuer(ISSUER)
+               .setIssuedAt(now)
+               .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME))
+               .signWith(getSigningKey(), SignatureAlgorithm.HS256).compact();
+  }
+
+  public void validateToken(String token) {
+    try {
+      getClaimsFromToken(token);
+    } catch (JwtException e) {
+      throw new InvalidJwtException(e.getMessage(), INVALID_JWT);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidJwtException(e.getMessage(), INVALID_JWT);
+    }
+  }
+
+  private Claims getClaimsFromToken(String token) {
+    return Jwts.parserBuilder().setSigningKey(getSigningKey()).build()
+               .parseClaimsJws(token).getBody();
+  }
+}

--- a/src/main/java/com/project/socket/security/exception/InvalidJwtException.java
+++ b/src/main/java/com/project/socket/security/exception/InvalidJwtException.java
@@ -1,0 +1,14 @@
+package com.project.socket.security.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidJwtException extends RuntimeException{
+  private ErrorCode errorCode;
+
+  public InvalidJwtException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/project/socket/security/oauth2/handler/LoginSuccessResponse.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/LoginSuccessResponse.java
@@ -1,0 +1,6 @@
+package com.project.socket.security.oauth2.handler;
+
+public record LoginSuccessResponse(
+    boolean profileSetup,
+    String accessToken,
+    String refreshToken) { }

--- a/src/main/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,32 @@
+package com.project.socket.security.oauth2.handler;
+
+import static com.project.socket.common.error.ErrorCode.OAUTH2_LOGIN_FAIL;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.error.ProblemDetailFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(APPLICATION_PROBLEM_JSON_VALUE);
+    objectMapper.writeValue(
+        response.getOutputStream(),
+        ProblemDetailFactory.of(OAUTH2_LOGIN_FAIL, request.getRequestURI()));
+  }
+}

--- a/src/main/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,59 @@
+package com.project.socket.security.oauth2.handler;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.security.JwtProvider;
+import com.project.socket.user.model.User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final Function<User, User> userRepositoryOAuth2UserHandler;
+  private final JwtProvider jwtProvider;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+    OAuth2AuthenticationToken oAuth2AuthenticationToken = (OAuth2AuthenticationToken) authentication;
+    User savedUser = userRepositoryOAuth2UserHandler.apply(
+        UserFactory.of(
+            oAuth2AuthenticationToken.getAuthorizedClientRegistrationId(),
+            oAuth2AuthenticationToken.getPrincipal().getAttributes()));
+
+    LoginSuccessResponse loginSuccessResponse = new LoginSuccessResponse(
+        savedUser.isProfileSetup(),
+        jwtProvider.createAccessToken(savedUser),
+        jwtProvider.createRefreshToken(savedUser));
+
+    setupResponse(response);
+
+    objectMapper.writeValue(response.getOutputStream(), loginSuccessResponse);
+  }
+
+  private void setupResponse(HttpServletResponse response) {
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType(APPLICATION_JSON_VALUE);
+    response.addCookie(createExpiredJSessionCookie());
+  }
+
+  private Cookie createExpiredJSessionCookie() {
+    Cookie jsessionid = new Cookie("JSESSIONID", null);
+    jsessionid.setMaxAge(0);
+    jsessionid.setPath("/");
+    return jsessionid;
+  }
+}

--- a/src/main/java/com/project/socket/security/oauth2/handler/UserFactory.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/UserFactory.java
@@ -5,10 +5,11 @@ import com.project.socket.user.model.SocialProvider;
 import com.project.socket.user.model.User;
 import java.util.Map;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
 
-@Component
 public class UserFactory {
+
+  private UserFactory() {
+  }
 
   public static User of(String provider, Map<String, Object> attribute) {
     return switch (provider) {
@@ -18,6 +19,7 @@ public class UserFactory {
       default -> throw new IllegalArgumentException();
     };
   }
+
   private static User googleUser(Map<String, Object> attribute) {
     return User.builder()
                .email(getValue(attribute, "email"))

--- a/src/main/java/com/project/socket/security/oauth2/handler/UserFactory.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/UserFactory.java
@@ -1,0 +1,60 @@
+package com.project.socket.security.oauth2.handler;
+
+import com.project.socket.user.model.Role;
+import com.project.socket.user.model.SocialProvider;
+import com.project.socket.user.model.User;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserFactory {
+
+  public static User of(String provider, Map<String, Object> attribute) {
+    return switch (provider) {
+      case "google" -> googleUser(attribute);
+      case "kakao" -> kakaoUser(attribute);
+      case "github" -> githubUser(attribute);
+      default -> throw new IllegalArgumentException();
+    };
+  }
+  private static User googleUser(Map<String, Object> attribute) {
+    return User.builder()
+               .email(getValue(attribute, "email"))
+               .role(Role.ROLE_USER)
+               .socialProvider(SocialProvider.GOOGLE)
+               .socialId(getValue(attribute, "sub"))
+               .build();
+  }
+
+  private static User kakaoUser(Map<String, Object> attribute) {
+    Map<String, Object> accountAttribute = getAttribute(attribute, "kakao_account");
+    return User.builder()
+               .email(getValue(accountAttribute, "email"))
+               .role(Role.ROLE_USER)
+               .socialProvider(SocialProvider.KAKAO)
+               .socialId(getValue(attribute, "id"))
+               .build();
+  }
+
+  private static User githubUser(Map<String, Object> attribute) {
+    return User.builder()
+               .socialProvider(SocialProvider.GITHUB)
+               .role(Role.ROLE_USER)
+               .socialId(getValue(attribute, "id"))
+               .email(getValue(attribute, "email"))
+               .build();
+  }
+
+  private static String getValue(Map<String, Object> attribute, String key) {
+    Object value = attribute.get(key);
+    if (Objects.isNull(value)) {
+      return null;
+    }
+    return value.toString();
+  }
+
+  private static Map<String, Object> getAttribute(Map<String, Object> attribute, String key) {
+    return (Map<String, Object>) attribute.get(key);
+  }
+}

--- a/src/main/java/com/project/socket/security/oauth2/handler/UserRepositoryOAuth2UserHandler.java
+++ b/src/main/java/com/project/socket/security/oauth2/handler/UserRepositoryOAuth2UserHandler.java
@@ -1,0 +1,29 @@
+package com.project.socket.security.oauth2.handler;
+
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryOAuth2UserHandler implements Function<User, User> {
+
+  private final UserJpaRepository userJpaRepository;
+
+  @Override
+  public User apply(User user) {
+    return findUser(user).orElseGet(() -> saveUser(user));
+  }
+
+  private Optional<User> findUser(User user) {
+    return userJpaRepository.findBySocialIdAndSocialProvider(user.getSocialId(),
+        user.getSocialProvider());
+  }
+
+  private User saveUser(User user) {
+    return userJpaRepository.save(user);
+  }
+}

--- a/src/main/java/com/project/socket/user/model/Role.java
+++ b/src/main/java/com/project/socket/user/model/Role.java
@@ -1,0 +1,5 @@
+package com.project.socket.user.model;
+
+public enum Role {
+  ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/project/socket/user/model/SocialProvider.java
+++ b/src/main/java/com/project/socket/user/model/SocialProvider.java
@@ -1,0 +1,5 @@
+package com.project.socket.user.model;
+
+public enum SocialProvider {
+  GOOGLE, GITHUB, KAKAO
+}

--- a/src/main/java/com/project/socket/user/model/User.java
+++ b/src/main/java/com/project/socket/user/model/User.java
@@ -1,0 +1,61 @@
+package com.project.socket.user.model;
+
+import com.project.socket.common.model.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@ToString
+@Getter
+@NoArgsConstructor
+public class User extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userId;
+
+  @Column
+  private String nickname;
+
+  @Column
+  private String githubLink;
+
+  @Column
+  private String email;
+
+  @Column(nullable = false)
+  private boolean profileSetup;
+
+  @Column(nullable = false)
+  private String socialId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SocialProvider socialProvider;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+  @Builder
+  public User(Long userId, String nickname, String githubLink, String email, boolean profileSetup,
+      String socialId, SocialProvider socialProvider, Role role) {
+    this.userId = userId;
+    this.nickname = nickname;
+    this.githubLink = githubLink;
+    this.email = email;
+    this.profileSetup = profileSetup;
+    this.socialId = socialId;
+    this.socialProvider = socialProvider;
+    this.role = role;
+  }
+}

--- a/src/main/java/com/project/socket/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/project/socket/user/repository/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package com.project.socket.user.repository;
+
+import com.project.socket.user.model.SocialProvider;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findBySocialIdAndSocialProvider(String socialId, SocialProvider socialProvider);
+}

--- a/src/main/resources/application-local-cors.yml
+++ b/src/main/resources/application-local-cors.yml
@@ -1,0 +1,2 @@
+cors:
+  allow-origins: http://localhost:3000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,13 +2,18 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      format_sql: true
       ddl-auto: validate
     show-sql: true
     open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
 
 logging:
   level:
     org.springframework.security: trace
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+
+jwt:
+  secret: socket-secret-key-for-local-please

--- a/src/main/resources/application-prod-cors.yml
+++ b/src/main/resources/application-prod-cors.yml
@@ -1,0 +1,2 @@
+cors:
+  allow-origins: ${CORS_ALLOW_ORIGINS}

--- a/src/main/resources/application-prod-security.yml
+++ b/src/main/resources/application-prod-security.yml
@@ -10,14 +10,14 @@ spring:
             user-name-attribute: id
         registration:
           github:
-            client-id: githubId
-            client-secret: githubSecret
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
             scope:
               - read:user
               - user:email
           kakao:
-            client-id: kakaoId
-            client-secret: kakaoSecret
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
@@ -25,35 +25,8 @@ spring:
               - profile_nickname
               - account_email
           google:
-            client-id: googleId
-            client-secret: googleSecret
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             scope:
               - profile
               - email
-  test:
-    database:
-      replace: none
-  datasource:
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-    url: jdbc:tc:mysql:8:///socket
-
-  jpa:
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
-    show-sql: true
-
-
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace
-
-jwt:
-  secret: socket-secret-key-for-test-please
-
-cors:
-  allow-origins: http://localhost:3000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,10 +7,12 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      format_sql: true
       ddl-auto: validate
     show-sql: true
     open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 
@@ -21,3 +23,6 @@ logging:
 
 server:
   shutdown: graceful
+
+jwt:
+  secret: ${JWT.KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,12 @@ spring:
       local:
         - flyway
         - localdb
+        - local-security
+        - local-cors
       prod:
         - flyway
+        - prod-cors
+        - prod-security
       test:
         - flyway
     active: local

--- a/src/main/resources/db/migration/V2__create_user_table.sql
+++ b/src/main/resources/db/migration/V2__create_user_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS user
+(
+    user_id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nickname        VARCHAR(255),
+    github_link     VARCHAR(255),
+    email           VARCHAR(255),
+    social_id       VARCHAR(255) NOT NULL,
+    social_provider VARCHAR(255) NOT NULL,
+    role            VARCHAR(255) NOT NULL,
+    profile_setup   TINYINT(1)   NOT NULL,
+    created_at      DATETIME(6)  NOT NULL,
+    modified_at     DATETIME(6)  NOT NULL
+);

--- a/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
+++ b/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
@@ -1,0 +1,41 @@
+package com.project.socket.common.error;
+
+import static com.project.socket.common.error.ErrorCode.OAUTH2_LOGIN_FAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ProblemDetailFactoryTest {
+
+  @Test
+  void 에러코드에_해당하는_ProblemDetail을_생성한다(){
+    ProblemDetail problemDetail = ProblemDetailFactory.from(OAUTH2_LOGIN_FAIL);
+
+    assertAll(
+        () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),
+        () -> assertThat(problemDetail.getTitle()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
+        () -> assertThat(problemDetail.getProperties().get("code"))
+            .isEqualTo(OAUTH2_LOGIN_FAIL.getCode())
+    );
+  }
+
+  @Test
+  void 에러코드와_instanceURI에_해당하는_ProblemDetail을_생성한다(){
+    URI instanceURI = URI.create("/some/request");
+    ProblemDetail problemDetail = ProblemDetailFactory.of(OAUTH2_LOGIN_FAIL, instanceURI.toString());
+
+    assertAll(
+        () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),
+        () -> assertThat(problemDetail.getTitle()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
+        () -> assertThat(problemDetail.getProperties().get("code"))
+            .isEqualTo(OAUTH2_LOGIN_FAIL.getCode()),
+        () -> assertThat(problemDetail.getInstance()).isEqualTo(instanceURI)
+    );
+  }
+}

--- a/src/test/java/com/project/socket/security/JwtProviderTest.java
+++ b/src/test/java/com/project/socket/security/JwtProviderTest.java
@@ -1,0 +1,63 @@
+package com.project.socket.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.project.socket.security.exception.InvalidJwtException;
+import com.project.socket.user.model.Role;
+import com.project.socket.user.model.User;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class JwtProviderTest {
+
+  JwtProvider jwtProvider = new JwtProvider("jwt-secret-key-for-test-profile-test");
+
+  @Test
+  void 유저_정보에_해당하는_access_token을_생성하고_반환한다() {
+    User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
+
+    String accessToken = jwtProvider.createAccessToken(user);
+
+    assertThat(accessToken).isNotNull();
+  }
+
+  @Test
+  void 유저_정보에_해당하는_refresh_token을_생성하고_반환한다() {
+    User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
+
+    String accessToken = jwtProvider.createRefreshToken(user);
+
+    assertThat(accessToken).isNotNull();
+  }
+
+  @Test
+  void 토큰이_null이면_InvalidJwtExeption_예외가_발생한다() {
+    assertThatThrownBy(() -> jwtProvider.validateToken(null))
+        .isInstanceOf(InvalidJwtException.class)
+        .hasMessage("JWT String argument cannot be null or empty.");
+  }
+
+  @Test
+  void 토큰이_빈_문자열이면_InvalidJwtExeption_예외가_발생한다() {
+    assertThatThrownBy(() -> jwtProvider.validateToken(""))
+        .isInstanceOf(InvalidJwtException.class)
+        .hasMessage("JWT String argument cannot be null or empty.");
+  }
+
+  @Test
+  void 토큰이_유효하지_않으면_InvalidJwtExeption_예외가_발생한다() {
+    assertThatThrownBy(() -> jwtProvider.validateToken("invalid.token.value"))
+        .isInstanceOf(InvalidJwtException.class);
+  }
+
+  @Test
+  void 유효한_토큰을_검증한다() {
+    User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
+    String accessToken = jwtProvider.createAccessToken(user);
+
+    jwtProvider.validateToken(accessToken);
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/LoginSuccessResponseTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/LoginSuccessResponseTest.java
@@ -1,0 +1,28 @@
+package com.project.socket.security.oauth2.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LoginSuccessResponseTest {
+
+  @Test
+  void 파라미터에_해당하는_LoginSuccessResponse_객체를_생성한다(){
+    final boolean PROFILE_SETUP = false;
+    final String ACCESS_TOKEN = "accessToken";
+    final String REFRESH_TOKEN = "refreshToken";
+
+    LoginSuccessResponse loginSuccessResponse = new LoginSuccessResponse(PROFILE_SETUP,
+        ACCESS_TOKEN, REFRESH_TOKEN);
+
+    assertAll(
+        () -> assertThat(loginSuccessResponse.profileSetup()).isFalse(),
+        () -> assertThat(loginSuccessResponse.accessToken()).isEqualTo(ACCESS_TOKEN),
+        () -> assertThat(loginSuccessResponse.refreshToken()).isEqualTo(REFRESH_TOKEN)
+    );
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandlerTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandlerTest.java
@@ -1,0 +1,48 @@
+package com.project.socket.security.oauth2.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginFailureHandlerTest {
+
+  MockHttpServletRequest request;
+  MockHttpServletResponse response;
+  @InjectMocks
+  OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+  @Mock
+  ObjectMapper objectMapper;
+
+  @BeforeEach
+  void init() {
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  void oauth2_로그인에_실패하면_401응답을_한다() throws ServletException, IOException {
+    oAuth2LoginFailureHandler.onAuthenticationFailure(
+        request, response, new OAuth2AuthenticationException("401"));
+    assertAll(
+        () -> assertThat(response.getStatus()).isEqualTo(401),
+        () -> assertThat(response.getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON_VALUE)
+    );
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandlerTest.java
@@ -1,0 +1,93 @@
+package com.project.socket.security.oauth2.handler;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.security.JwtProvider;
+import com.project.socket.user.model.User;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginSuccessHandlerTest {
+
+  MockHttpServletRequest request;
+  MockHttpServletResponse response;
+
+  @InjectMocks
+  OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+  @Mock
+  Function<User, User> userRepositoryOAuth2UserHandler;
+
+  @Mock
+  JwtProvider jwtProvider;
+
+  @Mock
+  ObjectMapper objectMapper;
+
+
+  @BeforeEach
+  void init() {
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  void OAuth2_로그인이_성공하면_LoginSuccessResponse_응답을_한다() throws ServletException, IOException {
+    try (MockedStatic<UserFactory> mockUserFactory = mockStatic(UserFactory.class)) {
+      mockUserFactory
+          .when(() -> UserFactory.of(anyString(), anyMap()))
+          .thenReturn(User.builder().build());
+
+      when(userRepositoryOAuth2UserHandler.apply(any())).thenReturn(User.builder().build());
+      when(jwtProvider.createAccessToken(any())).thenReturn("accessToken");
+      when(jwtProvider.createRefreshToken(any())).thenReturn("refreshToken");
+
+      oAuth2LoginSuccessHandler.onAuthenticationSuccess(request, response,
+          createAuthentication());
+
+      assertAll(
+          () -> assertThat(response.getStatus()).isEqualTo(SC_OK),
+          () -> assertThat(response.getContentType()).isEqualTo(APPLICATION_JSON_VALUE),
+          () -> verify(objectMapper).writeValue(eq(response.getOutputStream()),
+              any(LoginSuccessResponse.class))
+      );
+    }
+  }
+
+  OAuth2AuthenticationToken createAuthentication() {
+    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("role"));
+    OAuth2User oAuth2User = new DefaultOAuth2User(authorities, Map.of("id", "test"), "id");
+    return new OAuth2AuthenticationToken(oAuth2User, authorities, "provider");
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/UserFactoryTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/UserFactoryTest.java
@@ -48,6 +48,20 @@ class UserFactoryTest {
   }
 
   @Test
+  void email이_없는_github_attribute에_해당하는_유저를_반환한다() {
+    String givenProvider = "github";
+    Map<String, Object> givenAttribute = getEmptyEmailGithubAttribute();
+
+    User user = UserFactory.of(givenProvider, givenAttribute);
+
+    assertAll(
+        () -> assertThat(user.getSocialId()).isEqualTo(SOCIAL_ID),
+        () -> assertThat(user.getEmail()).isNull(),
+        () -> assertThat(user.getSocialProvider()).isEqualTo(GITHUB)
+    );
+  }
+
+  @Test
   void google_attribute에_해당하는_유저를_반환한다() {
     String givenProvider = "google";
     Map<String, Object> givenAttribute = getGoogleAttribute();
@@ -62,7 +76,7 @@ class UserFactoryTest {
   }
 
   @Test
-  void 지원하지않는_provider라면_IllegalArgumentException_예외가_발생한다(){
+  void 지원하지않는_provider라면_IllegalArgumentException_예외가_발생한다() {
     String givenProvider = "naver";
 
     assertThatThrownBy(() -> UserFactory.of(givenProvider, Map.of()))
@@ -80,5 +94,9 @@ class UserFactoryTest {
 
   private Map<String, Object> getGithubAttribute() {
     return Map.of("email", EMAIL, "id", SOCIAL_ID);
+  }
+
+  private Map<String, Object> getEmptyEmailGithubAttribute() {
+    return Map.of("id", SOCIAL_ID);
   }
 }

--- a/src/test/java/com/project/socket/security/oauth2/handler/UserFactoryTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/UserFactoryTest.java
@@ -1,0 +1,84 @@
+package com.project.socket.security.oauth2.handler;
+
+import static com.project.socket.user.model.SocialProvider.GITHUB;
+import static com.project.socket.user.model.SocialProvider.GOOGLE;
+import static com.project.socket.user.model.SocialProvider.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.project.socket.user.model.User;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UserFactoryTest {
+
+  private final String SOCIAL_ID = "123";
+  private final String EMAIL = "test@google.com";
+
+  @Test
+  void kakao_attribute에_해당하는_유저를_반환한다() {
+    String givenProvider = "kakao";
+    Map<String, Object> givenAttribute = getKakaoAttribute();
+
+    User user = UserFactory.of(givenProvider, givenAttribute);
+
+    assertAll(
+        () -> assertThat(user.getSocialId()).isEqualTo(SOCIAL_ID),
+        () -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+        () -> assertThat(user.getSocialProvider()).isEqualTo(KAKAO)
+    );
+  }
+
+  @Test
+  void github_attribute에_해당하는_유저를_반환한다() {
+    String givenProvider = "github";
+    Map<String, Object> givenAttribute = getGithubAttribute();
+
+    User user = UserFactory.of(givenProvider, givenAttribute);
+
+    assertAll(
+        () -> assertThat(user.getSocialId()).isEqualTo(SOCIAL_ID),
+        () -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+        () -> assertThat(user.getSocialProvider()).isEqualTo(GITHUB)
+    );
+  }
+
+  @Test
+  void google_attribute에_해당하는_유저를_반환한다() {
+    String givenProvider = "google";
+    Map<String, Object> givenAttribute = getGoogleAttribute();
+
+    User user = UserFactory.of(givenProvider, givenAttribute);
+
+    assertAll(
+        () -> assertThat(user.getSocialId()).isEqualTo(SOCIAL_ID),
+        () -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+        () -> assertThat(user.getSocialProvider()).isEqualTo(GOOGLE)
+    );
+  }
+
+  @Test
+  void 지원하지않는_provider라면_IllegalArgumentException_예외가_발생한다(){
+    String givenProvider = "naver";
+
+    assertThatThrownBy(() -> UserFactory.of(givenProvider, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private Map<String, Object> getKakaoAttribute() {
+    Map<String, String> kakaoAccount = Map.of("email", EMAIL);
+    return Map.of("kakao_account", kakaoAccount, "id", SOCIAL_ID);
+  }
+
+  private Map<String, Object> getGoogleAttribute() {
+    return Map.of("email", EMAIL, "sub", SOCIAL_ID);
+  }
+
+  private Map<String, Object> getGithubAttribute() {
+    return Map.of("email", EMAIL, "id", SOCIAL_ID);
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/UserRepositoryOAuth2UserHandlerTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/UserRepositoryOAuth2UserHandlerTest.java
@@ -1,0 +1,58 @@
+package com.project.socket.security.oauth2.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryOAuth2UserHandlerTest {
+
+  @InjectMocks
+  UserRepositoryOAuth2UserHandler userRepositoryOAuth2UserHandler;
+
+  @Mock
+  UserJpaRepository userJpaRepository;
+
+  @Test
+  void 해당_유저가_가입되어있지_않으면_저장하고_반환한다(){
+    User savedUser = User.builder().userId(1L).build();
+
+    when(userJpaRepository.findBySocialIdAndSocialProvider(any(), any()))
+        .thenReturn(Optional.empty());
+    when(userJpaRepository.save(any())).thenReturn(savedUser);
+
+    User user = userRepositoryOAuth2UserHandler.apply(User.builder().build());
+
+    assertThat(user.getUserId()).isEqualTo(savedUser.getUserId());
+  }
+
+  @Test
+  void 해당_유저가_가입되어있다면_찾은_유저를_반환한다(){
+    User registeredUser = User.builder().userId(1L).build();
+
+    when(userJpaRepository.findBySocialIdAndSocialProvider(any(), any()))
+        .thenReturn(Optional.of(registeredUser));
+
+    User user = userRepositoryOAuth2UserHandler.apply(User.builder().build());
+
+    assertAll(
+        () -> assertThat(user.getUserId()).isEqualTo(registeredUser.getUserId()),
+        () -> verify(userJpaRepository, never()).save(any())
+    );
+  }
+}

--- a/src/test/java/com/project/socket/user/repository/UserJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/user/repository/UserJpaRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.project.socket.user.repository;
+
+import static com.project.socket.user.model.SocialProvider.GOOGLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.project.socket.user.model.SocialProvider;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class UserJpaRepositoryTest {
+
+  @Autowired
+  UserJpaRepository userJpaRepository;
+
+  @Test
+  @Sql("findBySocialIdAndSocialProvider.sql")
+  void 조건에_해당하는_유저가_있다면_유저가_담긴_Optinal을_반환한다() {
+    final String SOCIAL_ID = "1234";
+    final SocialProvider SOCIAL_PROVIDER = GOOGLE;
+
+    Optional<User> optionalUser = userJpaRepository.findBySocialIdAndSocialProvider(
+        SOCIAL_ID, SOCIAL_PROVIDER);
+
+    assertThat(optionalUser).hasValueSatisfying(user -> {
+      assertAll(
+          () -> assertThat(user.getSocialId()).isEqualTo(SOCIAL_ID),
+          () -> assertThat(user.getSocialProvider()).isEqualTo(GOOGLE)
+      );
+    });
+  }
+
+  @Test
+  @Sql("findBySocialIdAndSocialProvider.sql")
+  void 조건에_해당하는_유저가_없다면_빈_Optinal을_반환한다() {
+    final String SOCIAL_ID = "1234";
+    final SocialProvider SOCIAL_PROVIDER = SocialProvider.KAKAO;
+
+    Optional<User> optionalUser = userJpaRepository.findBySocialIdAndSocialProvider(
+        SOCIAL_ID, SOCIAL_PROVIDER);
+
+    assertThat(optionalUser).isEmpty();
+  }
+}

--- a/src/test/resources/com/project/socket/user/repository/findBySocialIdAndSocialProvider.sql
+++ b/src/test/resources/com/project/socket/user/repository/findBySocialIdAndSocialProvider.sql
@@ -1,0 +1,2 @@
+insert into user (social_id, social_provider, role, profile_setup, created_at, modified_at)
+values ('1234','GOOGLE', 'ROLE_USER', false, now(), now());

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+  |===
+    |필드명|타입|필수여부|제약조건|설명
+  {{#fields}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+  {{/fields}}
+    |===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,17 @@
+  |===
+    |필드명|타입|필수여부|설명
+  {{#fields}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+  {{/fields}}
+    |===|===
+    |필드명|타입|필수여부|설명
+  {{#fields}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+  {{/fields}}
+    |===


### PR DESCRIPTION
## PR 요약
OAuth2 로그인 구현과 User Entity를 구현했습니다.

### OAuth2
- kakao
- google
- github

로그인이 성공적으로 수행되면 유저의 **프로필 설정 여부**,  **액세스토큰**, **리프레쉬토큰**이 담긴 200 응답이 갑니다.
액세스 토큰의 만료기간은 6시간, 리프레쉬 토큰의 만료기간은 2주입니다.

코드 변경 사항이 많아서 죄송합니다. 다음부터는 작업단위를 좀 나누어서 확인이 쉽도록 조절하겠습니다.
보시면서 이상하거나 궁금한 부분 있으시면 편하게 리뷰 남겨주시거나 연락주세요.
## 변경 사항
- Git에 안 올라간  application-local-security.yml 파일이 있습니다. 따로 파일을 보내 드릴테니 민오님 프로젝트 resource 디렉토리에 넣으시면 됩니다.

- User entity가 추가되어서 User table을 추가하는 V2 flyway 파일이 추가 되었습니다. 민오님이 구현하시는 부분의 추가 스크립트 파일은 V3로 바꿔주셔야됩니다.

#### Linked Issue

#13 