### PR TITLE
[FEAT] JwtFilter 적용

### DIFF
--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -2,8 +2,11 @@ package com.project.socket.common.error;
 
 public enum ErrorCode {
 
+  // Auth Error
   OAUTH2_LOGIN_FAIL(401, "A1", "로그인 실패"),
-  INVALID_JWT(401, "A2", "유효하지 않은 토큰입니다");
+  INVALID_JWT(401, "A2", "유효하지 않은 토큰입니다"),
+  HANDLE_ACCESS_DENIED(403, "A3", "권한이 없습니다"),
+  AUTHENTICATION_ENTRY_POINT(401, "A4", "인증이 필요합니다");
 
   private int status;
   private final String code;

--- a/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
+++ b/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
@@ -1,6 +1,7 @@
 package com.project.socket.common.error;
 
 import java.net.URI;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 
 public class ProblemDetailFactory {
@@ -11,7 +12,8 @@ public class ProblemDetailFactory {
   public static ProblemDetail from(ErrorCode errorCode) {
     ProblemDetail problemDetail = ProblemDetail
         .forStatus(errorCode.getStatus());
-    problemDetail.setTitle(errorCode.getMessage());
+    problemDetail.setTitle(HttpStatus.valueOf(errorCode.getStatus()).getReasonPhrase());
+    problemDetail.setDetail(errorCode.getMessage());
     problemDetail.setProperty("code", errorCode.getCode());
     return problemDetail;
   }

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.project.socket.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+import com.project.socket.security.filter.JwtFilter;
+import com.project.socket.security.handler.CustomAccessDeniedHandler;
+import com.project.socket.security.handler.CustomAuthenticationEntryPoint;
 import com.project.socket.security.oauth2.handler.OAuth2LoginFailureHandler;
 import com.project.socket.security.oauth2.handler.OAuth2LoginSuccessHandler;
 import java.util.Arrays;
@@ -14,6 +17,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -25,6 +29,9 @@ public class SecurityConfig {
 
   private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
   private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+  private final JwtFilter jwtFilter;
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+  private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -40,8 +47,12 @@ public class SecurityConfig {
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(formLogin -> formLogin.disable())
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/docs/**", "/actuator/**", "/", "/error/**").permitAll()
-            .anyRequest().authenticated());
+            .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
+            .anyRequest().authenticated())
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exceptionHandling -> exceptionHandling
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler));
     return http.build();
   }
 

--- a/src/main/java/com/project/socket/security/JwtProvider.java
+++ b/src/main/java/com/project/socket/security/JwtProvider.java
@@ -62,6 +62,14 @@ public class JwtProvider {
     }
   }
 
+  public String getSubjectFromToken(String token) {
+    return getClaimsFromToken(token).getSubject();
+  }
+
+  public String getRoleFromToken(String token) {
+    return getClaimsFromToken(token).get("role").toString();
+  }
+
   private Claims getClaimsFromToken(String token) {
     return Jwts.parserBuilder().setSigningKey(getSigningKey()).build()
                .parseClaimsJws(token).getBody();

--- a/src/main/java/com/project/socket/security/filter/JwtFilter.java
+++ b/src/main/java/com/project/socket/security/filter/JwtFilter.java
@@ -1,0 +1,63 @@
+package com.project.socket.security.filter;
+
+import com.project.socket.security.JwtProvider;
+import com.project.socket.security.exception.InvalidJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String AUTHORIZATION_TYPE = "Bearer ";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String jwtToken = getJwtFromRequest(request);
+
+    try {
+      jwtProvider.validateToken(jwtToken);
+      UserDetails userDetails = getUserDetails(jwtProvider.getSubjectFromToken(jwtToken),
+          jwtProvider.getRoleFromToken(jwtToken));
+      Authentication authentication = getAuthentication(userDetails);
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    } catch (InvalidJwtException invalidJwtException) {
+      request.setAttribute("exception", invalidJwtException.getErrorCode());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String getJwtFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AUTHORIZATION_TYPE)) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+
+  private Authentication getAuthentication(UserDetails userDetails) {
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  private UserDetails getUserDetails(String userId, String role) {
+    return User.builder().username(userId).password("").authorities(role).build();
+
+  }
+}

--- a/src/main/java/com/project/socket/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/project/socket/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.project.socket.security.handler;
+
+import static com.project.socket.common.error.ErrorCode.HANDLE_ACCESS_DENIED;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.error.ProblemDetailFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    setResponse(request, response);
+  }
+
+  private void setResponse(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    response.setContentType(APPLICATION_PROBLEM_JSON_VALUE);
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+    objectMapper.writeValue(
+        response.getOutputStream(),
+        ProblemDetailFactory.of(HANDLE_ACCESS_DENIED, request.getRequestURI()));
+  }
+}

--- a/src/main/java/com/project/socket/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/socket/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,51 @@
+package com.project.socket.security.handler;
+
+import static com.project.socket.common.error.ErrorCode.AUTHENTICATION_ENTRY_POINT;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.ProblemDetailFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    setResponse(request, response);
+  }
+
+  private ErrorCode getErrorCode(HttpServletRequest request) {
+    return (ErrorCode) request.getAttribute("exception");
+  }
+
+  private void setResponse(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    ErrorCode errorCode = getErrorCode(request);
+    response.setContentType(APPLICATION_PROBLEM_JSON_VALUE);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    if (Objects.isNull(errorCode)) {
+      objectMapper.writeValue(
+          response.getOutputStream(),
+          ProblemDetailFactory.of(AUTHENTICATION_ENTRY_POINT, request.getRequestURI()));
+    } else {
+      objectMapper.writeValue(
+          response.getOutputStream(),
+          ProblemDetailFactory.of(errorCode, request.getRequestURI()));
+    }
+  }
+}

--- a/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
+++ b/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
@@ -19,7 +19,7 @@ class ProblemDetailFactoryTest {
 
     assertAll(
         () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),
-        () -> assertThat(problemDetail.getTitle()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
+        () -> assertThat(problemDetail.getDetail()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
         () -> assertThat(problemDetail.getProperties().get("code"))
             .isEqualTo(OAUTH2_LOGIN_FAIL.getCode())
     );
@@ -32,7 +32,7 @@ class ProblemDetailFactoryTest {
 
     assertAll(
         () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),
-        () -> assertThat(problemDetail.getTitle()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
+        () -> assertThat(problemDetail.getDetail()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
         () -> assertThat(problemDetail.getProperties().get("code"))
             .isEqualTo(OAUTH2_LOGIN_FAIL.getCode()),
         () -> assertThat(problemDetail.getInstance()).isEqualTo(instanceURI)

--- a/src/test/java/com/project/socket/security/JwtProviderTest.java
+++ b/src/test/java/com/project/socket/security/JwtProviderTest.java
@@ -60,4 +60,21 @@ class JwtProviderTest {
 
     jwtProvider.validateToken(accessToken);
   }
+
+  @Test
+  void 토큰의_subject를_반환한다() {
+    String subject = jwtProvider.getSubjectFromToken(createValidToken());
+    assertThat(subject).isNotNull();
+  }
+
+  @Test
+  void 토큰의_role_claim을_반환한다() {
+    String role = jwtProvider.getRoleFromToken(createValidToken());
+    assertThat(role).isNotNull();
+  }
+
+  private String createValidToken() {
+    User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
+    return jwtProvider.createAccessToken(user);
+  }
 }

--- a/src/test/java/com/project/socket/security/MockAuthenticationException.java
+++ b/src/test/java/com/project/socket/security/MockAuthenticationException.java
@@ -1,0 +1,10 @@
+package com.project.socket.security;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class MockAuthenticationException extends AuthenticationException {
+
+  public MockAuthenticationException(String msg) {
+    super(msg);
+  }
+}

--- a/src/test/java/com/project/socket/security/filter/JwtFilterTest.java
+++ b/src/test/java/com/project/socket/security/filter/JwtFilterTest.java
@@ -1,0 +1,112 @@
+package com.project.socket.security.filter;
+
+import static com.project.socket.common.error.ErrorCode.INVALID_JWT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.security.JwtProvider;
+import com.project.socket.security.exception.InvalidJwtException;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class JwtFilterTest {
+
+  @InjectMocks
+  JwtFilter jwtFilter;
+
+  @Mock
+  JwtProvider jwtProvider;
+
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  MockHttpServletResponse response = new MockHttpServletResponse();
+  MockFilterChain filterChain = new MockFilterChain();
+
+
+  final String AUTHORIZATION_HEADER = "Authorization";
+  final String AUTHORIZATION_TYPE = "Bearer ";
+  final String TOKEN = "Token";
+
+  @AfterEach
+  void resetHeader() {
+    request.removeHeader(AUTHORIZATION_HEADER);
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void 인증_헤더에_유효한_토큰이_주어지면_인증_객체가_저장된다() throws ServletException, IOException {
+    request.addHeader(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + TOKEN);
+
+    doNothing().when(jwtProvider).validateToken(TOKEN);
+    when(jwtProvider.getSubjectFromToken(TOKEN)).thenReturn("1L");
+    when(jwtProvider.getRoleFromToken(TOKEN)).thenReturn("ROLE_USER");
+
+    jwtFilter.doFilterInternal(request, response, filterChain);
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+  }
+
+  @Test
+  void 인증_헤더에_유효하지_않은_토큰이_주어지면_인증_객체가_저장되지_않는다() throws ServletException, IOException {
+    request.addHeader(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + TOKEN);
+
+    doThrow(new InvalidJwtException("error", INVALID_JWT)).when(jwtProvider).validateToken(TOKEN);
+
+    jwtFilter.doFilterInternal(request, response, filterChain);
+
+    assertAll(
+        () -> assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull(),
+        () -> verify(jwtProvider, never()).getSubjectFromToken(anyString()),
+        () -> verify(jwtProvider, never()).getRoleFromToken(anyString()),
+        () -> assertThat(request.getAttribute("exception")).isNotNull()
+    );
+  }
+
+  @Test
+  void 인증_헤더가_없으면_인증_객체가_저장되지_않는다() throws ServletException, IOException {
+    doThrow(new InvalidJwtException("error", INVALID_JWT)).when(jwtProvider).validateToken(null);
+
+    jwtFilter.doFilterInternal(request, response, filterChain);
+
+    assertAll(
+        () -> assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull(),
+        () -> verify(jwtProvider, never()).getSubjectFromToken(anyString()),
+        () -> verify(jwtProvider, never()).getRoleFromToken(anyString()),
+        () -> assertThat(request.getAttribute("exception")).isNotNull()
+    );
+  }
+
+  @Test
+  void 인증_타입이_다르면_인증_객체가_저장되지_않는다() throws ServletException, IOException {
+    request.addHeader(AUTHORIZATION_HEADER, TOKEN);
+    doThrow(new InvalidJwtException("error", INVALID_JWT)).when(jwtProvider).validateToken(null);
+
+    jwtFilter.doFilterInternal(request, response, filterChain);
+
+    assertAll(
+        () -> assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull(),
+        () -> verify(jwtProvider, never()).getSubjectFromToken(anyString()),
+        () -> verify(jwtProvider, never()).getRoleFromToken(anyString()),
+        () -> assertThat(request.getAttribute("exception")).isNotNull()
+    );
+  }
+}

--- a/src/test/java/com/project/socket/security/handler/CustomAccessDeniedHandlerTest.java
+++ b/src/test/java/com/project/socket/security/handler/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,34 @@
+package com.project.socket.security.handler;
+
+import static com.project.socket.common.error.ErrorCode.HANDLE_ACCESS_DENIED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CustomAccessDeniedHandlerTest {
+
+  CustomAccessDeniedHandler customAccessDeniedHandler =
+      new CustomAccessDeniedHandler(new ObjectMapper());
+
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @Test
+  void HANDLE_ACCESS_DENIED_403_응답을_한다() throws ServletException, IOException {
+    customAccessDeniedHandler.handle(request, response, new AccessDeniedException("denied"));
+
+    String content = response.getContentAsString(Charset.defaultCharset());
+
+    assertThat(content).contains(HANDLE_ACCESS_DENIED.getCode());
+  }
+}

--- a/src/test/java/com/project/socket/security/handler/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/project/socket/security/handler/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,59 @@
+package com.project.socket.security.handler;
+
+import static com.project.socket.common.error.ErrorCode.AUTHENTICATION_ENTRY_POINT;
+import static com.project.socket.common.error.ErrorCode.INVALID_JWT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.security.MockAuthenticationException;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CustomAuthenticationEntryPointTest {
+
+  CustomAuthenticationEntryPoint customAuthenticationEntryPoint =
+      new CustomAuthenticationEntryPoint(new ObjectMapper());
+
+
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @AfterEach
+  void reset() {
+    request.removeAttribute("exception");
+    response.reset();
+  }
+
+  @Test
+  void request에_exception_attribute가_없으면_AUTHENTICATION_ENTRY_POINT_에러_응답을_한다()
+      throws ServletException, IOException {
+    customAuthenticationEntryPoint.commence(
+        request, response, new MockAuthenticationException("error"));
+
+    String content = response.getContentAsString(Charset.defaultCharset());
+
+    assertThat(content).contains(AUTHENTICATION_ENTRY_POINT.getCode());
+  }
+
+  @Test
+  void request에_exception_attribute가_존재하면_해당_에러_응답을_한다()
+      throws ServletException, IOException {
+    request.setAttribute("exception", INVALID_JWT);
+
+    customAuthenticationEntryPoint.commence(
+        request, response, new MockAuthenticationException("error"));
+
+    String content = response.getContentAsString(Charset.defaultCharset());
+
+    assertThat(content).contains(INVALID_JWT.getCode());
+  }
+
+}


### PR DESCRIPTION
## PR 요약

### JwtFilter
요청의 Authorization 헤더의 토큰 값으로 검증을하고 인증을 부여하는 JwtFilter를 구현했습니다.
security config에 특정 URI에 인증이 필요하다 설정을 해놓으면 해당 URI 요청을 위해서는 인증이 필요합니다.

>  ex) `requestMatchers( "/").hasAuthoriy("ROLE_USER")` / 에 접근하려면 ROLE_USER를 가진 인증객체가 필요.


JwtFilter를 통해 JWT가 유효한지 검증을 하고 유효하다면 토큰의 Claims의 Subject와 Role를 이용해 인증객체를 만들어 인증을 하고 다음 필터로 이동합니다.

###  CustomAuthenticationEntryPoint
인증이 필요한 요청인데 인증정보가 존재하지 않는다면 401응답을 처리하는 클래스입니다.

### CustomAccessDeniedHandler
권한이 없는 사용자의 요청이 오면 403응답을 처리하는 클래스 입니다.

> ex) ROLE_ADMIN 권한이 필요한데 현재 인증객체는 ROLE_USER 일때 

#### Linked Issue
close #19 