### PR TITLE
[FEAT] 공통 코드 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ sonar {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
-                '**/CommonDocController.java, **/ProblemDatailFieldDescription.java'
+                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ sonar {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*'
+        property 'sonar.test.exclusions', '**/CommonDocController.java, **/ProblemDatailFieldDescription.java'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,8 @@ sonar {
         property 'sonar.language', 'java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
-        property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*'
-        property 'sonar.test.exclusions', '**/CommonDocController.java, **/ProblemDatailFieldDescription.java'
+        property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
+                '**/CommonDocController.java, **/ProblemDatailFieldDescription.java'
     }
 }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,6 +6,11 @@
 :toclevels: 2
 :sectlinks:
 
+[[overview]]
+== Overview
+
+include::overview.adoc[]
+
 [[AUTH-API]]
 == Auth API
 

--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -1,0 +1,41 @@
+[[overview-host]]
+=== Host
+
+|===
+| 환경 | Host
+| Production
+| `api.socketing.site`
+|===
+
+[[overview-http-status-codes]]
+=== HTTP status codes
+
+|===
+| 상태 코드 | 설명
+
+| `200 OK`
+| 성공
+
+| `201 CREATED`
+| 성공적으로 생성됨
+
+| `400 Bad Request`
+| 잘못된 요청
+
+| `401 Unauthorized`
+| 비인증 상태
+
+| `403 Forbidden`
+| 권한 거부
+
+| `404 Not Found`
+| 존재하지 않는 요청 리소스
+
+| `500 Internal Server Error`
+| 서버 에러
+|===
+
+[[overview-error-response]]
+=== HTTP Error Response
+
+operation::sample-error-response[snippets='http-response,response-fields']

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -6,7 +6,10 @@ public enum ErrorCode {
   OAUTH2_LOGIN_FAIL(401, "A1", "로그인 실패"),
   INVALID_JWT(401, "A2", "유효하지 않은 토큰입니다"),
   HANDLE_ACCESS_DENIED(403, "A3", "권한이 없습니다"),
-  AUTHENTICATION_ENTRY_POINT(401, "A4", "인증이 필요합니다");
+  AUTHENTICATION_ENTRY_POINT(401, "A4", "인증이 필요합니다"),
+
+  // Common
+  INVALID_INPUT_VALUE(400, "C1", "올바르지 않은 입력 값입니다");
 
   private int status;
   private final String code;

--- a/src/main/java/com/project/socket/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/socket/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.project.socket.common.error;
+
+import static com.project.socket.common.error.ErrorCode.INVALID_INPUT_VALUE;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+      HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    ProblemDetail problemDetail = ProblemDetailFactory.of(
+        INVALID_INPUT_VALUE, ex.getBindingResult());
+    return ResponseEntity.badRequest().headers(headers).body(problemDetail);
+  }
+}

--- a/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
+++ b/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
@@ -58,7 +58,7 @@ public class ProblemDetailFactory {
                             error.getField(),
                             String.valueOf(error.getRejectedValue()),
                             error.getDefaultMessage()))
-                        .collect(Collectors.toList());
+                        .toList();
     }
   }
 }

--- a/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
+++ b/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
@@ -1,8 +1,15 @@
 package com.project.socket.common.error;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 public class ProblemDetailFactory {
 
@@ -13,14 +20,45 @@ public class ProblemDetailFactory {
     ProblemDetail problemDetail = ProblemDetail
         .forStatus(errorCode.getStatus());
     problemDetail.setTitle(HttpStatus.valueOf(errorCode.getStatus()).getReasonPhrase());
-    problemDetail.setDetail(errorCode.getMessage());
     problemDetail.setProperty("code", errorCode.getCode());
     return problemDetail;
   }
 
   public static ProblemDetail of(ErrorCode errorCode, String instanceURI) {
     ProblemDetail problemDetail = from(errorCode);
+    problemDetail.setDetail(errorCode.getMessage());
     problemDetail.setInstance(URI.create(instanceURI));
     return problemDetail;
+  }
+
+  public static ProblemDetail of(ErrorCode errorCode, BindingResult bindingResult) {
+    List<CustomFieldError> fieldErrors = CustomFieldError.of(bindingResult);
+    ProblemDetail problemDetail = from(errorCode);
+    problemDetail.setProperty("detail", fieldErrors);
+    return problemDetail;
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class CustomFieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private CustomFieldError(final String field, final String value, final String reason) {
+      this.field = field;
+      this.value = value;
+      this.reason = reason;
+    }
+
+    private static List<CustomFieldError> of(final BindingResult bindingResult) {
+      final List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+                        .map(error -> new CustomFieldError(
+                            error.getField(),
+                            String.valueOf(error.getRejectedValue()),
+                            error.getDefaultMessage()))
+                        .collect(Collectors.toList());
+    }
   }
 }

--- a/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
+++ b/src/main/java/com/project/socket/common/error/ProblemDetailFactory.java
@@ -2,7 +2,6 @@ package com.project.socket.common.error;
 
 import java.net.URI;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/test/java/com/project/socket/common/controller/CommonDocController.java
+++ b/src/test/java/com/project/socket/common/controller/CommonDocController.java
@@ -1,0 +1,19 @@
+package com.project.socket.common.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CommonDocController {
+
+  @PostMapping("/sample/error")
+  public void sampleError(@RequestBody @Valid SampleRequest sampleRequest) {
+
+  }
+
+  public record SampleRequest(@NotBlank String name, @Email String email) {}
+}

--- a/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
+++ b/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
@@ -1,0 +1,81 @@
+package com.project.socket.common.controller;
+
+import static com.project.socket.common.error.ProblemDetailFieldDescription.CODE;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.DETAIL;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.DETAIL_LIST_FIELD;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.DETAIL_LIST_REASON;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.DETAIL_LIST_VALUE;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.INSTANCE;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.STATUS;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.TITLE;
+import static com.project.socket.common.error.ProblemDetailFieldDescription.TYPE;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.controller.CommonDocController.SampleRequest;
+import com.project.socket.common.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+class CommonDocControllerTest {
+
+  ObjectMapper objectMapper = new ObjectMapper();
+  MockMvc mockMvc;
+  CommonDocController commonDocController = new CommonDocController();
+
+  @BeforeEach
+  void setup(RestDocumentationContextProvider restDocumentation) {
+    mockMvc = MockMvcBuilders.standaloneSetup(commonDocController)
+                             .apply(documentationConfiguration(restDocumentation))
+                             .setControllerAdvice(GlobalExceptionHandler.class)
+                             .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                             .build();
+  }
+
+  @Test
+  void test() throws Exception {
+    SampleRequest sampleRequest = new SampleRequest("", "email");
+    mockMvc.perform(
+               post("/sample/error")
+                   .contentType(MediaType.APPLICATION_JSON)
+                   .content(objectMapper.writeValueAsBytes(sampleRequest)))
+           .andExpect(status().isBadRequest())
+           .andDo(
+               document("sample-error-response",
+                   preprocessRequest(prettyPrint()),
+                   preprocessResponse(prettyPrint()),
+                   responseFields(
+                       fieldWithPath(TYPE.getField()).description(TYPE.getDescription()),
+                       fieldWithPath(TITLE.getField()).description(TITLE.getDescription()),
+                       fieldWithPath(STATUS.getField()).description(STATUS.getDescription()),
+                       fieldWithPath(DETAIL.getField()).description(DETAIL.getDescription()),
+                       fieldWithPath(DETAIL_LIST_FIELD.getField())
+                           .description(DETAIL_LIST_FIELD.getDescription()),
+                       fieldWithPath(DETAIL_LIST_VALUE.getField())
+                           .description(DETAIL_LIST_VALUE.getDescription()),
+                       fieldWithPath(DETAIL_LIST_REASON.getField())
+                           .description(DETAIL_LIST_REASON.getDescription()),
+                       fieldWithPath(INSTANCE.getField()).description(INSTANCE.getDescription()),
+                       fieldWithPath(CODE.getField()).description(CODE.getDescription())
+                   )
+               )
+           );
+  }
+}

--- a/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
+++ b/src/test/java/com/project/socket/common/error/ProblemDetailFactoryTest.java
@@ -14,21 +14,21 @@ import org.springframework.http.ProblemDetail;
 class ProblemDetailFactoryTest {
 
   @Test
-  void 에러코드에_해당하는_ProblemDetail을_생성한다(){
+  void 에러코드에_해당하는_ProblemDetail을_생성한다() {
     ProblemDetail problemDetail = ProblemDetailFactory.from(OAUTH2_LOGIN_FAIL);
 
     assertAll(
         () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),
-        () -> assertThat(problemDetail.getDetail()).isEqualTo(OAUTH2_LOGIN_FAIL.getMessage()),
         () -> assertThat(problemDetail.getProperties().get("code"))
             .isEqualTo(OAUTH2_LOGIN_FAIL.getCode())
     );
   }
 
   @Test
-  void 에러코드와_instanceURI에_해당하는_ProblemDetail을_생성한다(){
+  void 에러코드와_instanceURI에_해당하는_ProblemDetail을_생성한다() {
     URI instanceURI = URI.create("/some/request");
-    ProblemDetail problemDetail = ProblemDetailFactory.of(OAUTH2_LOGIN_FAIL, instanceURI.toString());
+    ProblemDetail problemDetail = ProblemDetailFactory.of(OAUTH2_LOGIN_FAIL,
+        instanceURI.toString());
 
     assertAll(
         () -> assertThat(problemDetail.getStatus()).isEqualTo(OAUTH2_LOGIN_FAIL.getStatus()),

--- a/src/test/java/com/project/socket/common/error/ProblemDetailFieldDescription.java
+++ b/src/test/java/com/project/socket/common/error/ProblemDetailFieldDescription.java
@@ -1,0 +1,29 @@
+package com.project.socket.common.error;
+
+public enum ProblemDetailFieldDescription {
+  TYPE("type", "문제 유형을 식별하는 URI 참고"),
+  TITLE("title", "문제 유형"),
+  STATUS("status", "Http status 코드"),
+  DETAIL("detail", "문제 유형 설명"),
+  INSTANCE("instance", "문제가 발생한 URI"),
+  CODE("code", "팀에서 정의한 에러코드"),
+  DETAIL_LIST_FIELD("detail[0].field", "문제있는 필드"),
+  DETAIL_LIST_VALUE("detail[0].value", "문제있는 값"),
+  DETAIL_LIST_REASON("detail[0].reason", "문제 원인");
+
+  private String field;
+  private String description;
+
+  ProblemDetailFieldDescription(String field, String description) {
+    this.field = field;
+    this.description = description;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/src/test/java/com/project/socket/security/JwtProviderTest.java
+++ b/src/test/java/com/project/socket/security/JwtProviderTest.java
@@ -34,21 +34,21 @@ class JwtProviderTest {
   }
 
   @Test
-  void 토큰이_null이면_InvalidJwtExeption_예외가_발생한다() {
+  void 토큰이_null이면_InvalidJwtException_예외가_발생한다() {
     assertThatThrownBy(() -> jwtProvider.validateToken(null))
         .isInstanceOf(InvalidJwtException.class)
         .hasMessage("JWT String argument cannot be null or empty.");
   }
 
   @Test
-  void 토큰이_빈_문자열이면_InvalidJwtExeption_예외가_발생한다() {
+  void 토큰이_빈_문자열이면_InvalidJwtException_예외가_발생한다() {
     assertThatThrownBy(() -> jwtProvider.validateToken(""))
         .isInstanceOf(InvalidJwtException.class)
         .hasMessage("JWT String argument cannot be null or empty.");
   }
 
   @Test
-  void 토큰이_유효하지_않으면_InvalidJwtExeption_예외가_발생한다() {
+  void 토큰이_유효하지_않으면_InvalidJwtException_예외가_발생한다() {
     assertThatThrownBy(() -> jwtProvider.validateToken("invalid.token.value"))
         .isInstanceOf(InvalidJwtException.class);
   }

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,10 +1,10 @@
-  |===
-    |필드명|타입|필수여부|제약조건|설명
-  {{#fields}}
-    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
-    |{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
-    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-  {{/fields}}
-    |===
+|===
+|필드명|타입|필수여부|제약조건|설명
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,17 +1,9 @@
-  |===
-    |필드명|타입|필수여부|설명
-  {{#fields}}
-    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
-    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-  {{/fields}}
-    |===|===
-    |필드명|타입|필수여부|설명
-  {{#fields}}
-    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
-    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-  {{/fields}}
-    |===
+|===
+|필드명|타입|필수여부|설명
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+|===


### PR DESCRIPTION
## PR 요약
공통 코드 문서화 작업을 했습니다.

Host, Http status, Sample 에러 응답을 문서화 했습니다.

CommonDocController는 테스트 코드 영역에 만들었기 때문에 실제로 api가 만들어지진 않습니다.

- ProblemDetailFieldDescription : 테스트코드 작성시 problemDetail의 필드와 설명을 enum으로 만들어 재사용하게 했습니다.

#### Linked Issue
close #21 