### PR TITLE
FIX OAuth2 로그인 응답 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,13 +150,13 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'BRANCH' // 조건문 등의 분기 수
                 value = 'COVEREDRATIO'
-                minimum = 0.0
+                minimum = 0.80
             }
 
             limit {
                 counter = 'LINE' // 빈 줄을 제외한 실제 코드 라인수
                 value = 'COVEREDRATIO'
-                minimum = 0.0
+                minimum = 0.80
             }
 
             // jacocoTestReport의 작성과 다르게 패키지 + 클래스명을 적어야함

--- a/src/docs/asciidoc/auth/auth.adoc
+++ b/src/docs/asciidoc/auth/auth.adoc
@@ -1,30 +1,14 @@
-[[kakao-login]]
-=== 카카오 로그인
+[[login]]
+=== 로그인 요청
 
-==== HTTP Request
-include::kakao-login/http-request.adoc[]
+operation::oauth2-login-redirect[snippets='http-request,path-parameters,query-parameters,http-response']
 
-==== HTTP Response
-include::kakao-login/http-response.adoc[]
-include::kakao-login/response-fields.adoc[]
+=== 로그인 완료 후 리다이렉트
 
-[[github-login]]
-=== 깃허브 로그인
+==== 성공
+==== HTTP response
+include::success-redirect.adoc[]
 
-==== HTTP Request
-include::github-login/http-request.adoc[]
-
-==== HTTP Response
-include::github-login/http-response.adoc[]
-include::github-login/response-fields.adoc[]
-
-[[google-login]]
-=== 구글 로그인
-
-==== HTTP Request
-include::google-login/http-request.adoc[]
-
-==== HTTP Response
-include::google-login/http-response.adoc[]
-include::google-login/response-fields.adoc[]
-
+==== 에러
+==== HTTP response
+include::fail-redirect.adoc[]

--- a/src/docs/asciidoc/auth/fail-redirect.adoc
+++ b/src/docs/asciidoc/auth/fail-redirect.adoc
@@ -1,0 +1,29 @@
+[source,http,options="nowrap"]
+----
+HTTP/1.1 302 Found
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Location: redired_url?error=error
+----
+
+|===
+
+|`+redirect_url+`
+|로그인 이후 토큰 결과를 받을 URL
+|ex) http://localhost:3000/login/oauth/token?error=에러입니다.
+
+ ex) http://localhost:3000/?error=에러입니다.
+
+|===
+
+|===
+|Parameter|Description
+
+|`+error+`
+|에러 메세지
+
+|===

--- a/src/docs/asciidoc/auth/success-redirect.adoc
+++ b/src/docs/asciidoc/auth/success-redirect.adoc
@@ -1,0 +1,32 @@
+[source,http,options="nowrap"]
+----
+HTTP/1.1 302 Found
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Location: redired_url?accessToken=accessToken&refreshToken=refreshToken&profileSetup=false
+----
+
+|===
+
+|`+redirect_url+`
+|로그인 이후 토큰 결과를 받을 URL
+
+|===
+
+|===
+|Parameter|Description
+
+|`+accessToken+`
+|액세스 토큰
+
+|`+refreshToken+`
+|리프레쉬 로큰
+
+|`+profileSetup+`
+|프로필 설정 여부 true, false
+
+|===

--- a/src/main/java/com/project/socket/security/JwtProvider.java
+++ b/src/main/java/com/project/socket/security/JwtProvider.java
@@ -55,9 +55,7 @@ public class JwtProvider {
   public void validateToken(String token) {
     try {
       getClaimsFromToken(token);
-    } catch (JwtException e) {
-      throw new InvalidJwtException(e.getMessage(), INVALID_JWT);
-    } catch (IllegalArgumentException e) {
+    } catch (JwtException | IllegalArgumentException e) {
       throw new InvalidJwtException(e.getMessage(), INVALID_JWT);
     }
   }

--- a/src/test/java/com/project/socket/security/CookieUtilsTest.java
+++ b/src/test/java/com/project/socket/security/CookieUtilsTest.java
@@ -1,0 +1,110 @@
+package com.project.socket.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.Cookie;
+import java.util.Base64;
+import java.util.Optional;
+import org.hibernate.internal.util.SerializationHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CookieUtilsTest {
+
+  public static final String VALID_NAME = "cookie";
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @BeforeEach
+  void setup() {
+    request = new MockHttpServletRequest();
+    response.reset();
+  }
+
+  @Test
+  void cookies가_null이면_Empty_Optional을_반환한다() {
+    Optional<Cookie> cookie = CookieUtils.getCookie(request, "name");
+
+    assertThat(cookie).isEmpty();
+  }
+
+  @Test
+  void cookies가_비어있는_array면_Empty_Optional을_반환한다() {
+    Optional<Cookie> cookie = CookieUtils.getCookie(new MockRequest(), "empty");
+
+    assertThat(cookie).isEmpty();
+  }
+
+  @Test
+  void name에_해당하는_cookie가_없으면_Empty_Optional을_반환한다() {
+    request.setCookies(new Cookie(VALID_NAME, "cookie"));
+    Optional<Cookie> cookie = CookieUtils.getCookie(request, "name");
+
+    assertThat(cookie).isEmpty();
+  }
+
+  @Test
+  void name에_해당하는_cookie가_있으면_값이_담긴_Optional을_반환한다() {
+    request.setCookies(new Cookie(VALID_NAME, "cookie"));
+    Optional<Cookie> cookie = CookieUtils.getCookie(request, "cookie");
+
+    assertThat(cookie).isNotEmpty();
+  }
+
+  @Test
+  void response에_cookie를_추가한다() {
+    CookieUtils.addCookie(response, VALID_NAME, "cookie", 1);
+
+    assertThat(response.getCookie(VALID_NAME)).isNotNull();
+  }
+
+  @Test
+  void name에_해당하는_cookie를_삭제한다() {
+    request.setCookies(new Cookie(VALID_NAME, "cookie"));
+    CookieUtils.deleteCookie(request, response, VALID_NAME);
+
+    assertThat(response.getCookie(VALID_NAME).getMaxAge()).isZero();
+  }
+
+  @Test
+  void name에_해당하는_cookie가_없으면_response에_삭제된_쿠키정보가_존재하지_않는다() {
+    CookieUtils.deleteCookie(request, response, VALID_NAME);
+
+    assertThat(response.getCookie(VALID_NAME)).isNull();
+  }
+
+  @Test
+  void url을_직렬화하고_Base64_인코딩한다() {
+    String url = "http://localhost:8080";
+    String serializedValue = CookieUtils.serialize(url);
+    Object deserialize = SerializationHelper.deserialize(
+        Base64.getUrlDecoder().decode(serializedValue));
+
+    assertThat(deserialize).hasToString(url);
+  }
+
+  @Test
+  void cookie_value를_Base64_디코딩하고_역직렬화한다() {
+    String url = "http://localhost:8080";
+    CookieUtils.addCookie(response, VALID_NAME, CookieUtils.serialize(url), 1);
+    Cookie cookie = response.getCookie(VALID_NAME);
+
+    String deserializedValue = CookieUtils.deserialize(cookie, String.class);
+
+    assertThat(deserializedValue).isEqualTo(url);
+  }
+
+  private static class MockRequest extends MockHttpServletRequest {
+
+    @Override
+    public Cookie[] getCookies() {
+      return new Cookie[]{};
+    }
+  }
+
+}

--- a/src/test/java/com/project/socket/security/OAuth2LoginTest.java
+++ b/src/test/java/com/project/socket/security/OAuth2LoginTest.java
@@ -1,6 +1,5 @@
 package com.project.socket.security;
 
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -12,6 +11,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.project.socket.security.filter.JwtFilter;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -25,13 +26,14 @@ import org.springframework.test.web.servlet.MockMvc;
     type = FilterType.ASSIGNABLE_TYPE, classes = JwtFilter.class))
 @ActiveProfiles("test")
 @AutoConfigureRestDocs
-public class OAuth2LoginTest {
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class OAuth2LoginTest {
 
   @Autowired
   MockMvc mockMvc;
 
   @Test
-  void test() throws Exception {
+  void 로그인_요청을_하면_해당_페이지로_302_리다이렉트한다() throws Exception {
     mockMvc.perform(get("/oauth2/authorization/{provider}", "google")
                .queryParam("redirect_url", "http://localhost:3000/login/callback"))
            .andExpect(status().is3xxRedirection())
@@ -40,8 +42,7 @@ public class OAuth2LoginTest {
                preprocessResponse(prettyPrint()),
                pathParameters(parameterWithName("provider").description("kakao, google, github")),
                queryParameters(
-                   parameterWithName("redirect_url").description("로그인 이후 토큰 결과를 받을 URL")),
-               responseHeaders()
+                   parameterWithName("redirect_url").description("로그인 이후 토큰 결과를 받을 URL"))
            ));
   }
 }

--- a/src/test/java/com/project/socket/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.project.socket.security.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.project.socket.security.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+
+  MockHttpServletRequest request = new MockHttpServletRequest();
+  MockHttpServletResponse response = new MockHttpServletResponse();
+  HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository
+      = new HttpCookieOAuth2AuthorizationRequestRepository();
+
+  final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_url";
+  final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+
+  @BeforeEach
+  void setup() {
+    request = new MockHttpServletRequest();
+    response.reset();
+  }
+
+  @Test
+  void request_쿠키에서_AuthorizationRequest를_가져와_역직렬화한다() {
+    OAuth2AuthorizationRequest oAuth2AuthorizationRequest =
+        OAuth2AuthorizationRequest.authorizationCode().clientId("clientId").authorizationUri("URI")
+                                  .build();
+
+    request.setCookies(
+        new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtils.serialize(oAuth2AuthorizationRequest)));
+
+    OAuth2AuthorizationRequest authorizationRequest =
+        httpCookieOAuth2AuthorizationRequestRepository.loadAuthorizationRequest(request);
+
+    assertThat(authorizationRequest.getClientId())
+        .isEqualTo(oAuth2AuthorizationRequest.getClientId());
+  }
+
+  @Test
+  void request에_oauth2_auth_request_쿠키가_없으면_null을_반환한다() {
+    OAuth2AuthorizationRequest authorizationRequest =
+        httpCookieOAuth2AuthorizationRequestRepository.loadAuthorizationRequest(request);
+
+    assertThat(authorizationRequest).isNull();
+  }
+
+  @Test
+  void authorizationRequest가_null이면_인증_쿠키를_제거한다() {
+    request.setCookies(new MockCookie(REDIRECT_URI_PARAM_COOKIE_NAME, "url"));
+
+    httpCookieOAuth2AuthorizationRequestRepository
+        .saveAuthorizationRequest(null, request, response);
+
+    assertThat(response.getCookie(REDIRECT_URI_PARAM_COOKIE_NAME).getMaxAge()).isZero();
+  }
+
+  @Test
+  void redirect_url쿼리가_존재하면_response에_redirect_url_쿠키를_추가한다() {
+    request.addParameter(REDIRECT_URI_PARAM_COOKIE_NAME, "url");
+    OAuth2AuthorizationRequest oAuth2AuthorizationRequest =
+        OAuth2AuthorizationRequest.authorizationCode().clientId("clientId").authorizationUri("URI")
+                                  .build();
+
+    httpCookieOAuth2AuthorizationRequestRepository
+        .saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+
+    assertThat(response.getCookie(REDIRECT_URI_PARAM_COOKIE_NAME).getMaxAge()).isNotZero();
+  }
+
+  @Test
+  void redirect_url쿼리가_존재지않으면_response에_redirect_url_쿠키를_추가하지않는다() {
+    OAuth2AuthorizationRequest oAuth2AuthorizationRequest =
+        OAuth2AuthorizationRequest.authorizationCode().clientId("clientId").authorizationUri("URI")
+                                  .build();
+
+    httpCookieOAuth2AuthorizationRequestRepository
+        .saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
+
+    assertThat(response.getCookie(REDIRECT_URI_PARAM_COOKIE_NAME)).isNull();
+  }
+
+  @Test
+  void 인증요청_쿠키와_redirect_url_쿠키를_삭제한다() {
+    request.setCookies(
+        new MockCookie(REDIRECT_URI_PARAM_COOKIE_NAME, "url"),
+        new MockCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "oauth2"));
+
+    httpCookieOAuth2AuthorizationRequestRepository
+        .removeAuthorizationRequestCookies(request, response);
+
+    assertAll(
+        () -> assertThat(response.getCookie(REDIRECT_URI_PARAM_COOKIE_NAME).getMaxAge())
+            .isZero(),
+        () -> assertThat(response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME).getMaxAge())
+            .isZero()
+    );
+  }
+
+  @Test
+  void removeAuthorizationRequest_테스트() {
+    OAuth2AuthorizationRequest authorizationRequest =
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequest(
+            request, response);
+
+    assertThat(authorizationRequest).isNull();
+  }
+}

--- a/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandlerTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginFailureHandlerTest.java
@@ -1,20 +1,27 @@
 package com.project.socket.security.oauth2.handler;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-import java.io.IOException;
+import com.project.socket.security.CookieUtils;
+import com.project.socket.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import jakarta.servlet.http.Cookie;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -22,27 +29,39 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 class OAuth2LoginFailureHandlerTest {
-//
-//  MockHttpServletRequest request;
-//  MockHttpServletResponse response;
-//  @InjectMocks
-//  OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-//  @Mock
-//  ObjectMapper objectMapper;
-//
-//  @BeforeEach
-//  void init() {
-//    request = new MockHttpServletRequest();
-//    response = new MockHttpServletResponse();
-//  }
-//
-//  @Test
-//  void oauth2_로그인에_실패하면_401응답을_한다() throws ServletException, IOException {
-//    oAuth2LoginFailureHandler.onAuthenticationFailure(
-//        request, response, new OAuth2AuthenticationException("401"));
-//    assertAll(
-//        () -> assertThat(response.getStatus()).isEqualTo(401),
-//        () -> assertThat(response.getContentType()).isEqualTo(APPLICATION_PROBLEM_JSON_VALUE)
-//    );
-//  }
+
+  MockHttpServletRequest request;
+  MockHttpServletResponse response;
+  @InjectMocks
+  OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+  @Mock
+  HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+  @BeforeEach
+  void init() {
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideOptionalCookie")
+  void oauth2_로그인에_실패하면_target_url로_redirect_한다(Optional<Cookie> cookie) {
+    try (MockedStatic<CookieUtils> mockCookieUtils = mockStatic(CookieUtils.class)) {
+      mockCookieUtils.when(() -> CookieUtils.getCookie(any(), any()))
+                     .thenReturn(cookie);
+
+      doNothing().when(httpCookieOAuth2AuthorizationRequestRepository)
+                 .removeAuthorizationRequestCookies(any(), any());
+
+      assertThatCode(() -> oAuth2LoginFailureHandler.onAuthenticationFailure(
+          request, response, new OAuth2AuthenticationException("fail"))).doesNotThrowAnyException();
+    }
+  }
+
+  private static Stream<Arguments> provideOptionalCookie() {
+    return Stream.of(
+        Arguments.of(Optional.of(new MockCookie("test", "test"))),
+        Arguments.of(Optional.empty())
+    );
+  }
 }

--- a/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/com/project/socket/security/oauth2/handler/OAuth2LoginSuccessHandlerTest.java
@@ -1,25 +1,23 @@
 package com.project.socket.security.oauth2.handler;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.security.CookieUtils;
 import com.project.socket.security.JwtProvider;
+import com.project.socket.security.exception.RedirectBadRequestException;
+import com.project.socket.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.project.socket.user.model.User;
-import jakarta.servlet.ServletException;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -29,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -39,55 +38,74 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 class OAuth2LoginSuccessHandlerTest {
-//
-//  MockHttpServletRequest request;
-//  MockHttpServletResponse response;
-//
-//  @InjectMocks
-//  OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-//
-//  @Mock
-//  Function<User, User> userRepositoryOAuth2UserHandler;
-//
-//  @Mock
-//  JwtProvider jwtProvider;
-//
-//  @Mock
-//  ObjectMapper objectMapper;
-//
-//
-//  @BeforeEach
-//  void init() {
-//    request = new MockHttpServletRequest();
-//    response = new MockHttpServletResponse();
-//  }
-//
-//  @Test
-//  void OAuth2_로그인이_성공하면_LoginSuccessResponse_응답을_한다() throws ServletException, IOException {
-//    try (MockedStatic<UserFactory> mockUserFactory = mockStatic(UserFactory.class)) {
-//      mockUserFactory
-//          .when(() -> UserFactory.of(anyString(), anyMap()))
-//          .thenReturn(User.builder().build());
-//
-//      when(userRepositoryOAuth2UserHandler.apply(any())).thenReturn(User.builder().build());
-//      when(jwtProvider.createAccessToken(any())).thenReturn("accessToken");
-//      when(jwtProvider.createRefreshToken(any())).thenReturn("refreshToken");
-//
-//      oAuth2LoginSuccessHandler.onAuthenticationSuccess(request, response,
-//          createAuthentication());
-//
-//      assertAll(
-//          () -> assertThat(response.getStatus()).isEqualTo(SC_OK),
-//          () -> assertThat(response.getContentType()).isEqualTo(APPLICATION_JSON_VALUE),
-//          () -> verify(objectMapper).writeValue(eq(response.getOutputStream()),
-//              any(LoginSuccessResponse.class))
-//      );
-//    }
-//  }
-//
-//  OAuth2AuthenticationToken createAuthentication() {
-//    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("role"));
-//    OAuth2User oAuth2User = new DefaultOAuth2User(authorities, Map.of("id", "test"), "id");
-//    return new OAuth2AuthenticationToken(oAuth2User, authorities, "provider");
-//  }
+
+  MockHttpServletRequest request;
+  MockHttpServletResponse response;
+
+  @InjectMocks
+  OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+  @Mock
+  UnaryOperator<User> userRepositoryOAuth2UserHandler;
+
+  @Mock
+  JwtProvider jwtProvider;
+
+  @Mock
+  HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+
+  @BeforeEach
+  void init() {
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  void OAuth2_로그인이_성공하면_redirect_한다() {
+    try (MockedStatic<UserFactory> mockUserFactory = mockStatic(UserFactory.class);
+        MockedStatic<CookieUtils> mockCookieUtils = mockStatic(CookieUtils.class)) {
+      mockUserFactory
+          .when(() -> UserFactory.of(anyString(), anyMap()))
+          .thenReturn(User.builder().build());
+
+      mockCookieUtils
+          .when(() -> CookieUtils.getCookie(any(), any()))
+          .thenReturn(Optional.of(new MockCookie("test", "test")));
+
+      when(userRepositoryOAuth2UserHandler.apply(any())).thenReturn(User.builder().build());
+      doNothing().when(httpCookieOAuth2AuthorizationRequestRepository)
+                 .removeAuthorizationRequestCookies(any(), any());
+      when(jwtProvider.createAccessToken(any())).thenReturn("accessToken");
+      when(jwtProvider.createRefreshToken(any())).thenReturn("refreshToken");
+
+      assertThatCode(() -> oAuth2LoginSuccessHandler.onAuthenticationSuccess(request, response,
+          createAuthentication())).doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void redirect_url_쿠키가_없으면_RedirectBadRequestException_에외가_발생한다() {
+    try (MockedStatic<UserFactory> mockUserFactory = mockStatic(UserFactory.class);
+        MockedStatic<CookieUtils> mockCookieUtils = mockStatic(CookieUtils.class)
+    ) {
+      mockUserFactory
+          .when(() -> UserFactory.of(anyString(), anyMap()))
+          .thenReturn(User.builder().build());
+      mockCookieUtils
+          .when(() -> CookieUtils.getCookie(any(), any()))
+          .thenReturn(Optional.empty());
+      OAuth2AuthenticationToken authentication = createAuthentication();
+
+      when(userRepositoryOAuth2UserHandler.apply(any())).thenReturn(User.builder().build());
+      assertThatThrownBy(() -> oAuth2LoginSuccessHandler.onAuthenticationSuccess(request, response,
+          authentication)).isInstanceOf(RedirectBadRequestException.class);
+    }
+  }
+
+  OAuth2AuthenticationToken createAuthentication() {
+    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("role"));
+    OAuth2User oAuth2User = new DefaultOAuth2User(authorities, Map.of("id", "test"), "id");
+    return new OAuth2AuthenticationToken(oAuth2User, authorities, "provider");
+  }
 }


### PR DESCRIPTION
## PR 요약
OAuth2 로그인 응답 방식을 변경했습니다. 

기존 응답 방식은 Authorization Code 를 callback 받는 페이지에서 바로 토큰 정보를 출력했지만 프론트에서 받을 수 없는 문제가 생겨
로그인 요청시 응답을 받는 redirect_url 을 query parameter로 명시하고 서버에선 로그인을 완료한 뒤 redirect_url + 토큰 정보 파라미터를 아래와 같이 redirect 하는 방식으로 변경했습니다.

> redirect_url?accessToken=accessToken&refreshToken=refreshToken&profileSetup=false

그래서 기존의 구현되어있는 `AuthorizationRequestRepository` 는 세션으로 인증요청을 저장하고 있지만 새로 구현한 
`HttpCookieOAuth2AuthorizationRequestRepository` 는 쿠키로 `OAuth2AuthorizationRequest` 과 `redircet_url`을 저장해가며 여러 인증 과정간에 정보를 저장해 사용합니다. 

로그인 요청시 redirect_url 파라미터가 없거나, 로그인 중 문제가 발생하면 FailHandler를 통해 에러페이지로 redirect 시킵니다.

> redirect_url?error=message or /?error=message

#### Linked Issue
close #27 