### PR TITLE
[FEAT] 추가입력을 받아 회원가입을 완료하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,8 @@ sonar {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
-                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/RestDocsAttributeFactory.java'
+                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/RestDocsAttributeFactory.java,' +
+                '**/SecurityTestConfig.java'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ sonar {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
-                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java'
+                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/RestDocsAttributeFactory.java'
     }
 }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,5 @@ include::overview.adoc[]
 == Auth API
 
 include::auth/auth.adoc[]
+
+include::signup.adoc[]

--- a/src/docs/asciidoc/signup.adoc
+++ b/src/docs/asciidoc/signup.adoc
@@ -1,0 +1,4 @@
+[[signup]]
+=== 추가정보 입력 회원가입
+
+operation::signup[snippets='http-request,request-headers,request-fields,http-response,response-fields']

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -10,7 +10,13 @@ public enum ErrorCode {
   REDIRECT_BAD_REQUEST(400, "A5", "잘못된 요청입니다"),
 
   // Common
-  INVALID_INPUT_VALUE(400, "C1", "올바르지 않은 입력 값입니다");
+  INVALID_INPUT_VALUE(400, "C1", "올바르지 않은 입력 값입니다"),
+  INTERNAL_SERVER_ERROR(500, "C2", "서버 에러"),
+
+  //User
+  USER_NOT_FOUND(404, "U1", "해당 유저가 존재하지 않습니다"),
+  DUPLICATED_NICKNAME(400, "U2", "중복된 닉네임입니다");
+
 
   private int status;
   private final String code;

--- a/src/main/java/com/project/socket/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/socket/common/error/GlobalExceptionHandler.java
@@ -2,23 +2,39 @@ package com.project.socket.common.error;
 
 import static com.project.socket.common.error.ErrorCode.INVALID_INPUT_VALUE;
 
+import com.project.socket.common.error.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   @Override
   protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
       HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    log.error("Exception : {}, Message : {}", ex.getClass(), ex.getMessage());
     ProblemDetail problemDetail = ProblemDetailFactory.of(
         INVALID_INPUT_VALUE, ex.getBindingResult());
     return ResponseEntity.badRequest().headers(headers).body(problemDetail);
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ProblemDetail> handleBusinessException(BusinessException e,
+      HttpServletRequest request) {
+    log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());
+    ErrorCode errorCode = e.getErrorCode();
+    return new ResponseEntity<>(
+        ProblemDetailFactory.of(errorCode, request.getRequestURI()),
+        HttpStatusCode.valueOf(errorCode.getStatus()));
   }
 }

--- a/src/main/java/com/project/socket/common/error/exception/BusinessException.java
+++ b/src/main/java/com/project/socket/common/error/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.project.socket.common.error.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BusinessException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
         .formLogin(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
+            .requestMatchers("/signup").authenticated()
             .anyRequest().authenticated())
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/src/main/java/com/project/socket/user/controller/SignupController.java
+++ b/src/main/java/com/project/socket/user/controller/SignupController.java
@@ -1,0 +1,29 @@
+package com.project.socket.user.controller;
+
+import com.project.socket.user.controller.dto.request.SignupRequestDto;
+import com.project.socket.user.controller.dto.response.SignupResponseDto;
+import com.project.socket.user.model.User;
+import com.project.socket.user.service.usecase.SignupUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SignupController {
+
+  private final SignupUseCase signupUseCase;
+
+  @PatchMapping("/signup")
+  public ResponseEntity<SignupResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails) {
+    long userId = Long.parseLong(userDetails.getUsername());
+    User updatedUser = signupUseCase.signup(signupRequestDto.toCommand(userId));
+    return ResponseEntity.ok(SignupResponseDto.from(updatedUser));
+  }
+}

--- a/src/main/java/com/project/socket/user/controller/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/project/socket/user/controller/dto/request/SignupRequestDto.java
@@ -1,0 +1,12 @@
+package com.project.socket.user.controller.dto.request;
+
+import com.project.socket.user.service.SignupCommand;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+
+public record SignupRequestDto(@NotBlank String nickname, @URL String githubLink) {
+
+  public SignupCommand toCommand(Long userId) {
+    return new SignupCommand(userId, nickname, githubLink);
+  }
+}

--- a/src/main/java/com/project/socket/user/controller/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/project/socket/user/controller/dto/response/SignupResponseDto.java
@@ -1,0 +1,10 @@
+package com.project.socket.user.controller.dto.response;
+
+import com.project.socket.user.model.User;
+
+public record SignupResponseDto(String nickname, String githubLink) {
+
+  public static SignupResponseDto from(User user) {
+    return new SignupResponseDto(user.getNickname(), user.getGithubLink());
+  }
+}

--- a/src/main/java/com/project/socket/user/exception/DuplicatedNicknameException.java
+++ b/src/main/java/com/project/socket/user/exception/DuplicatedNicknameException.java
@@ -1,0 +1,11 @@
+package com.project.socket.user.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class DuplicatedNicknameException extends BusinessException {
+
+  public DuplicatedNicknameException() {
+    super(ErrorCode.DUPLICATED_NICKNAME);
+  }
+}

--- a/src/main/java/com/project/socket/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/project/socket/user/exception/UserNotFoundException.java
@@ -1,0 +1,12 @@
+package com.project.socket.user.exception;
+
+import static com.project.socket.common.error.ErrorCode.USER_NOT_FOUND;
+
+import com.project.socket.common.error.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+
+  public UserNotFoundException(Long userId) {
+    super("User ID: " + userId, USER_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/socket/user/model/User.java
+++ b/src/main/java/com/project/socket/user/model/User.java
@@ -58,4 +58,9 @@ public class User extends BaseTime {
     this.socialProvider = socialProvider;
     this.role = role;
   }
+
+  public void updateAdditionalInfo(String nickname, String githubLink) {
+    this.nickname = nickname;
+    this.githubLink = githubLink;
+  }
 }

--- a/src/main/java/com/project/socket/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/project/socket/user/repository/UserJpaRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
   Optional<User> findBySocialIdAndSocialProvider(String socialId, SocialProvider socialProvider);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/project/socket/user/service/SignupCommand.java
+++ b/src/main/java/com/project/socket/user/service/SignupCommand.java
@@ -1,0 +1,5 @@
+package com.project.socket.user.service;
+
+public record SignupCommand(Long userId, String nickname, String githubLink) {
+
+}

--- a/src/main/java/com/project/socket/user/service/SignupService.java
+++ b/src/main/java/com/project/socket/user/service/SignupService.java
@@ -1,0 +1,37 @@
+package com.project.socket.user.service;
+
+import com.project.socket.user.exception.DuplicatedNicknameException;
+import com.project.socket.user.exception.UserNotFoundException;
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import com.project.socket.user.service.usecase.SignupUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class SignupService implements SignupUseCase {
+
+  private final UserJpaRepository userJpaRepository;
+
+  @Override
+  @Transactional
+  public User signup(SignupCommand signupCommand) {
+    checkDuplicatedNickname(signupCommand.nickname());
+    User userForUpdate = findUser(signupCommand.userId());
+    userForUpdate.updateAdditionalInfo(signupCommand.nickname(), signupCommand.githubLink());
+    return userForUpdate;
+  }
+
+  private void checkDuplicatedNickname(String nickname) {
+    boolean isDuplicatedNickname = userJpaRepository.existsByNickname(nickname);
+    if (isDuplicatedNickname) {
+      throw new DuplicatedNicknameException();
+    }
+  }
+
+  private User findUser(Long userId) {
+    return userJpaRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+  }
+}

--- a/src/main/java/com/project/socket/user/service/usecase/SignupUseCase.java
+++ b/src/main/java/com/project/socket/user/service/usecase/SignupUseCase.java
@@ -1,0 +1,9 @@
+package com.project.socket.user.service.usecase;
+
+import com.project.socket.user.model.User;
+import com.project.socket.user.service.SignupCommand;
+
+public interface SignupUseCase {
+
+  User signup(SignupCommand signupCommand);
+}

--- a/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
+++ b/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
@@ -67,13 +67,13 @@ class CommonDocControllerTest {
                        fieldWithPath(STATUS.getField()).description(STATUS.getDescription()),
                        fieldWithPath(DETAIL.getField()).description(DETAIL.getDescription()),
                        fieldWithPath(DETAIL_LIST_FIELD.getField())
-                           .description(DETAIL_LIST_FIELD.getDescription()),
+                           .description(DETAIL_LIST_FIELD.getDescription()).optional(),
                        fieldWithPath(DETAIL_LIST_VALUE.getField())
-                           .description(DETAIL_LIST_VALUE.getDescription()),
+                           .description(DETAIL_LIST_VALUE.getDescription()).optional(),
                        fieldWithPath(DETAIL_LIST_REASON.getField())
-                           .description(DETAIL_LIST_REASON.getDescription()),
+                           .description(DETAIL_LIST_REASON.getDescription()).optional(),
                        fieldWithPath(INSTANCE.getField()).description(INSTANCE.getDescription()),
-                       fieldWithPath(CODE.getField()).description(CODE.getDescription())
+                       fieldWithPath(CODE.getField()).description(CODE.getDescription()).optional()
                    )
                )
            );

--- a/src/test/java/com/project/socket/common/error/ProblemDetailFieldDescription.java
+++ b/src/test/java/com/project/socket/common/error/ProblemDetailFieldDescription.java
@@ -7,9 +7,9 @@ public enum ProblemDetailFieldDescription {
   DETAIL("detail", "문제 유형 설명"),
   INSTANCE("instance", "문제가 발생한 URI"),
   CODE("code", "팀에서 정의한 에러코드"),
-  DETAIL_LIST_FIELD("detail[0].field", "문제있는 필드"),
-  DETAIL_LIST_VALUE("detail[0].value", "문제있는 값"),
-  DETAIL_LIST_REASON("detail[0].reason", "문제 원인");
+  DETAIL_LIST_FIELD("detail[].field", "문제있는 필드"),
+  DETAIL_LIST_VALUE("detail[].value", "문제있는 값"),
+  DETAIL_LIST_REASON("detail[].reason", "문제 원인");
 
   private String field;
   private String description;

--- a/src/test/java/com/project/socket/config/SecurityTestConfig.java
+++ b/src/test/java/com/project/socket/config/SecurityTestConfig.java
@@ -1,0 +1,21 @@
+package com.project.socket.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class SecurityTestConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .sessionManagement(sessionManager -> sessionManager
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .csrf(csrf -> csrf.disable());
+
+    return http.build();
+  }
+}

--- a/src/test/java/com/project/socket/docs/RestDocsAttributeFactory.java
+++ b/src/test/java/com/project/socket/docs/RestDocsAttributeFactory.java
@@ -1,0 +1,13 @@
+package com.project.socket.docs;
+
+import org.junit.jupiter.api.Disabled;
+import org.springframework.restdocs.snippet.Attributes.Attribute;
+
+@Disabled
+public class RestDocsAttributeFactory {
+
+  public static Attribute constraintsField(String description) {
+    return new Attribute("constraints", description);
+  }
+
+}

--- a/src/test/java/com/project/socket/security/OAuth2LoginTest.java
+++ b/src/test/java/com/project/socket/security/OAuth2LoginTest.java
@@ -10,20 +10,18 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.project.socket.security.filter.JwtFilter;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(excludeFilters = @ComponentScan.Filter(
-    type = FilterType.ASSIGNABLE_TYPE, classes = JwtFilter.class))
+@SpringBootTest
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @AutoConfigureRestDocs
 @DisplayNameGeneration(ReplaceUnderscores.class)

--- a/src/test/java/com/project/socket/user/controller/SignupControllerTest.java
+++ b/src/test/java/com/project/socket/user/controller/SignupControllerTest.java
@@ -1,0 +1,194 @@
+package com.project.socket.user.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.config.SecurityTestConfig;
+import com.project.socket.docs.RestDocsAttributeFactory;
+import com.project.socket.security.filter.JwtFilter;
+import com.project.socket.user.controller.dto.request.SignupRequestDto;
+import com.project.socket.user.exception.DuplicatedNicknameException;
+import com.project.socket.user.exception.UserNotFoundException;
+import com.project.socket.user.model.User;
+import com.project.socket.user.service.usecase.SignupUseCase;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@WebMvcTest(controllers = SignupController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = JwtFilter.class))
+@AutoConfigureRestDocs
+@Import(SecurityTestConfig.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SignupControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  SignupUseCase signupUseCase;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  final String NICKNAME = "nickname";
+  final String GITHUB_LINK = "https://github.com";
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 유효한_요청이_오면_업데이트_정보가_담긴_200_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto(NICKNAME, GITHUB_LINK);
+    User givenUser = User.builder().nickname(NICKNAME).githubLink(GITHUB_LINK).build();
+
+    when(signupUseCase.signup(any())).thenReturn(givenUser);
+
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andExpectAll(
+               status().isOk(),
+               jsonPath("$.nickname").value(NICKNAME),
+               jsonPath("$.githubLink").value(GITHUB_LINK)
+           )
+           .andExpect(status().isOk())
+           .andDo(
+               document("signup",
+                   preprocessRequest(prettyPrint()),
+                   preprocessResponse(prettyPrint()),
+                   requestHeaders(
+                       headerWithName("Authorization").description("Bearer access-token")
+                   ),
+                   requestFields(
+                       fieldWithPath("nickname")
+                           .type(JsonFieldType.STRING).description("닉네임")
+                           .attributes(RestDocsAttributeFactory.constraintsField("널 x, 공백 x")),
+                       fieldWithPath("githubLink")
+                           .type(JsonFieldType.STRING).optional().description("깃허브 주소")
+                           .attributes(RestDocsAttributeFactory.constraintsField("URL 형식"))
+                   ),
+                   responseFields(
+                       fieldWithPath("nickname").description("업데이트 된 닉네임"),
+                       fieldWithPath("githubLink").description("업데이트 된 깃허브 주소")
+                   )
+               )
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void nickname_필드가_null이면_400_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto(null, GITHUB_LINK);
+
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andExpectAll(
+               status().isBadRequest(),
+               jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()),
+               result -> assertThat(result.getResolvedException())
+                   .isInstanceOf(MethodArgumentNotValidException.class)
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void nickname_필드가_빈_문자열이면_400_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto("", GITHUB_LINK);
+
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andExpectAll(
+               status().isBadRequest(),
+               jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()),
+               result -> assertThat(result.getResolvedException())
+                   .isInstanceOf(MethodArgumentNotValidException.class)
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void githubLink_필드가_URL_형식이_아니면_400_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto(NICKNAME, "not url");
+
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andExpectAll(
+               status().isBadRequest(),
+               jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()),
+               result -> assertThat(result.getResolvedException())
+                   .isInstanceOf(MethodArgumentNotValidException.class)
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 닉네임이_중복이면_400_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto(NICKNAME, GITHUB_LINK);
+
+    when(signupUseCase.signup(any())).thenThrow(new DuplicatedNicknameException());
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andExpectAll(
+               status().isBadRequest(),
+               jsonPath("$.code").value(ErrorCode.DUPLICATED_NICKNAME.getCode()),
+               result -> assertThat(result.getResolvedException())
+                   .isInstanceOf(DuplicatedNicknameException.class)
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 유저가_존재하지_않으면_404_응답을_한다() throws Exception {
+    SignupRequestDto requestDto = new SignupRequestDto(NICKNAME, GITHUB_LINK);
+
+    when(signupUseCase.signup(any())).thenThrow(new UserNotFoundException(1L));
+    mockMvc.perform(patch("/signup")
+               .header("Authorization", "Bearer access-token")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(requestDto)))
+           .andDo(print())
+           .andExpectAll(
+               status().isNotFound(),
+               jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.getCode()),
+               result -> assertThat(result.getResolvedException())
+                   .isInstanceOf(UserNotFoundException.class)
+           );
+  }
+}

--- a/src/test/java/com/project/socket/user/repository/UserJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/user/repository/UserJpaRepositoryTest.java
@@ -51,4 +51,17 @@ class UserJpaRepositoryTest {
 
     assertThat(optionalUser).isEmpty();
   }
+
+  @Test
+  @Sql("existsByNicknameTest.sql")
+  void nickname에_해당하는_유저가_있다면_true를_반환한다() {
+    boolean result = userJpaRepository.existsByNickname("nickname");
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void nickname에_해당하는_유저가_없다면_false를_반환한다() {
+    boolean result = userJpaRepository.existsByNickname("nickname");
+    assertThat(result).isFalse();
+  }
 }

--- a/src/test/java/com/project/socket/user/service/SignupServiceTest.java
+++ b/src/test/java/com/project/socket/user/service/SignupServiceTest.java
@@ -1,0 +1,77 @@
+package com.project.socket.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.user.exception.DuplicatedNicknameException;
+import com.project.socket.user.exception.UserNotFoundException;
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class SignupServiceTest {
+
+  @InjectMocks
+  SignupService signupService;
+
+  @Mock
+  UserJpaRepository userJpaRepository;
+
+  @Test
+  void nickname이_중복되면_DuplicatedNicknameException_예외가_발생한다() {
+    SignupCommand command = createCommand();
+    when(userJpaRepository.existsByNickname(anyString())).thenReturn(true);
+
+    assertAll(
+        () -> assertThatThrownBy(() -> signupService.signup(command))
+            .isInstanceOf(DuplicatedNicknameException.class),
+        () -> verify(userJpaRepository, never()).findById(any())
+    );
+  }
+
+  @Test
+  void id에_해당하는_유저가_존재하지_않으면_UserNotFoundException_예외가_발생한다() {
+    SignupCommand command = createCommand();
+    when(userJpaRepository.existsByNickname(anyString())).thenReturn(false);
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertAll(
+        () -> assertThatThrownBy(() -> signupService.signup(command))
+            .isInstanceOf(UserNotFoundException.class)
+    );
+  }
+
+  @Test
+  void 성공적으로_정보를_업데이트하고_유저를_반환한다() {
+    SignupCommand command = createCommand();
+    User givenUser = User.builder().userId(command.userId()).build();
+    when(userJpaRepository.existsByNickname(anyString())).thenReturn(false);
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(givenUser));
+
+    User updatedUser = signupService.signup(command);
+    assertAll(
+        () -> assertThat(updatedUser.getGithubLink()).isEqualTo(command.githubLink()),
+        () -> assertThat(updatedUser.getNickname()).isEqualTo(command.nickname())
+    );
+  }
+
+  SignupCommand createCommand() {
+    return new SignupCommand(1L, "nickname", "githubLink");
+  }
+}

--- a/src/test/resources/com/project/socket/user/repository/existsByNicknameTest.sql
+++ b/src/test/resources/com/project/socket/user/repository/existsByNicknameTest.sql
@@ -1,0 +1,3 @@
+insert into user (nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values ('nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());


### PR DESCRIPTION
## PR 요약
### 추가입력을 받아서 회원가입을 완료하는 기능 구현
- 해당 API는 jwt token이 있어야 접근이 가능합니다.
- githubLink는 필수는 아니지만 입력됐을 경우 URL 형식에 맞아야지 통과됩니다.
- nickname의 제약조건은 null 이거나 빈 문자열, 공백만 있는 문자열이 아닌 경우 입니다. 이후에 특수문자, 길이 제한을 추가해야될 것 같습니다.
- 해당 유저 정보가 존재하지 않거나, nickname이 중복되는 경우 404, 400 응답을 합니다.

### GlobalExceptionHandler 구현
- 로직 처리 중 예외가 발생하면 해당 예외에 맞는 에러 응답을 처리해주는 클래스입니다.
- Spring에 기본적으로 정의되어있는 예외는 `ResponseEntityExceptionHandler` 에서 처리 로직이 구현되어있는데 저희 서비스의 에러 형식에 맞게 하기 위해 오버라이딩해 커스텀해 사용합니다.
- 저희 서비스에서 일어나는 예외의 최상위 클래스는 `BusinessException` 으로 `RuntimeException` 을 상속했습니다. 새로운 예외를 정의할 땐 `BusinessException` 을 상속해 만들고 그에 맞는 에러코드를 `ErrorCode enum`  에 추가해 사용하면됩니다. 제가 구현한 `UserNotFoundException.java, DuplicatedNicknameException.java` 를 참고하시면 좋을 것 같습니다!!

### 테스트 코드 작성
- 테스트 환경에서 사용할 `csrf.disable` 된 `SecurityTestConfig` 를 추가했습니다. Controller 테스트시 필요하시면 `@Import` 어노테이션으로 사용하시면 됩니다.
- /signup api 는 인증정보가 있어야 사용 가능하고 인증정보를 통해 ID를 가져옵니다.
  -  테스트시 `@WithMockUser(username = "1", authorities = "ROLE_USER")` 추가하면 인증객체가 추가된 상태로 테스트를 진행하게 됩니다. 

### Rest Docs Custom Field를 추가하는 Factory class 추가
constraints 는 기존에 존재하지 않는 Attribute입니다. 그래서 해당 내용을 문서에 추가하려면 아래와 같이 새로운 Attribute를 생성해 넣어줘야 됩니다.

``` java
fieldWithPath("nickname")
                           .type(JsonFieldType.STRING).description("닉네임")
                           .attributes(new Attribute("constraints", "널 x, 공백 x"));
```

하지만 constraints attribute 는 요청 문서에서 빈번하게 사용되기 때문에 재사용성을 높이기 위해 `RestDocsAttributeFactory` 팩토리 클래스를 추가해 아래와 같이 생성해 사용할 수 있습니다.

``` java
fieldWithPath("nickname")
                           .type(JsonFieldType.STRING).description("닉네임")
                           .attributes(RestDocsAttributeFactory.constraintsField("널 x, 공백 x"))
```

## 변경 사항
OAuth2LoginTest에서 빈들을 가져오는데 문제가 생겨 `@SpringBootTest` 로 변경했습니다.

#### Linked Issue
close #25 