### PR TITLE
[FEAT] comment table 수정과 댓글 추가 api 수정

### DIFF
--- a/src/main/java/com/project/socket/comment/model/Comment.java
+++ b/src/main/java/com/project/socket/comment/model/Comment.java
@@ -36,46 +36,34 @@ public class Comment extends BaseTime {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")   //단방향매핑
-  private User user;
+  private User writer;
 
   private String content;                       // 댓글 내용
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Comment parentComment;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "comment_status")
   private CommentStatus commentStatus;                       // 댓글 상태
 
-  @Column(name = "group_num")
-  private Long groupNum;                        // 댓글 그룹
-
-  @Column(name = "group_order")
-  private int groupOrder;                      // 댓글과 대댓글 순서
-
-  @Column(name = "comment_class")
-  private int commentClass;                    // 계층
-
-  public void setupGroupNum(Long commentId) {
-    this.groupNum = commentId;
-  }
-
   public static Comment createNewComment(Post postToAddComment, User writer, String content) {
     return Comment.builder()
-                  .user(writer).cPost(postToAddComment)
+                  .writer(writer).cPost(postToAddComment)
                   .content(content)
                   .commentStatus(CommentStatus.CREATED)
-                  .commentClass(0)
                   .build();
   }
 
   @Builder
-  public Comment(Long id, Post cPost, User user, String content, CommentStatus commentStatus,
-      Long groupNum, int groupOrder, int commentClass) {
+  public Comment(Long id, Post cPost, User writer, String content, Comment parentComment,
+      CommentStatus commentStatus) {
     this.id = id;
     this.cPost = cPost;
-    this.user = user;
+    this.writer = writer;
     this.content = content;
+    this.parentComment = parentComment;
     this.commentStatus = commentStatus;
-    this.groupNum = groupNum;
-    this.groupOrder = groupOrder;
-    this.commentClass = commentClass;
   }
 }

--- a/src/main/java/com/project/socket/comment/service/AddCommentService.java
+++ b/src/main/java/com/project/socket/comment/service/AddCommentService.java
@@ -32,7 +32,6 @@ public class AddCommentService implements AddCommentUseCase {
         postToAddComment, writer, addCommentCommand.content());
 
     Comment savedComment = saveComment(commentToSave);
-    savedComment.setupGroupNum(savedComment.getId());
     return savedComment;
   }
 

--- a/src/main/resources/db/migration/V5__change_comment_table.sql
+++ b/src/main/resources/db/migration/V5__change_comment_table.sql
@@ -1,0 +1,12 @@
+ALTER TABLE comment
+    DROP group_num,
+    DROP group_order,
+    DROP comment_class;
+
+ALTER TABLE comment
+    ADD COLUMN parent_id BIGINT;
+
+ALTER TABLE comment
+    ADD CONSTRAINT fk_comment_parent
+        FOREIGN KEY (parent_id)
+            REFERENCES comment (comment_id)

--- a/src/test/java/com/project/socket/comment/model/CommentTest.java
+++ b/src/test/java/com/project/socket/comment/model/CommentTest.java
@@ -27,10 +27,9 @@ class CommentTest {
     Comment newComment = Comment.createNewComment(post, user, CONTENT);
 
     assertThat(newComment).satisfies(comment -> {
-          assertThat(comment.getCommentClass()).isZero();
           assertThat(comment.getContent()).isEqualTo(CONTENT);
           assertThat(comment.getCommentStatus()).isEqualTo(CommentStatus.CREATED);
-          assertThat(comment.getGroupOrder()).isZero();
+          assertThat(comment.getParentComment()).isNull();
         }
     );
   }

--- a/src/test/java/com/project/socket/comment/repository/CommentJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/comment/repository/CommentJpaRepositoryTest.java
@@ -31,12 +31,14 @@ class CommentJpaRepositoryTest {
     Optional<User> writer = userJpaRepository.findById(1L);
     Optional<Post> post = postJpaRepository.findById(1L);
     Comment comment = Comment.builder()
-                             .user(writer.get()).cPost(post.get())
+                             .writer(writer.get()).cPost(post.get())
                              .content("sdf")
                              .build();
 
     Comment savedComment = commentJpaRepository.save(comment);
-
-    assertThat(savedComment.getId()).isNotNull();
+    assertThat(savedComment).satisfies(c -> {
+      assertThat(c.getId()).isNotNull();
+      assertThat(c.getParentComment()).isNull();
+    });
   }
 }

--- a/src/test/java/com/project/socket/comment/service/AddCommentServiceTest.java
+++ b/src/test/java/com/project/socket/comment/service/AddCommentServiceTest.java
@@ -84,7 +84,7 @@ class AddCommentServiceTest {
     Post postToSaveComment = Post.builder().id(1L).build();
     Comment comment = Comment.builder()
                              .id(1L)
-                             .content(command.content()).user(writer).cPost(postToSaveComment)
+                             .content(command.content()).writer(writer).cPost(postToSaveComment)
                              .build();
 
     when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(writer));

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -49,7 +49,6 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
 
 jwt:


### PR DESCRIPTION
## PR 요약
### comment table 수정
- groupNum, groupOrder, commentClass 삭제
- 자기자신과 연관관계를 가지는 순환 참조 관계 설정. parentComment
- parent == null ? 부모 댓글 : 대댓글

### 댓글 추가 기능 api 
- 테이블 변경에 따른 기존 로직, 테스트 코드 수정

## 변경 사항
V5__change_comment_table.sql

#### Linked Issue
close #36 