### PR TITLE
[FEAT] 댓글 수정 구현

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -7,3 +7,8 @@ operation::addComment[snippets='http-request,path-parameters,request-headers,req
 === 대댓글 추가
 
 operation::addReply[snippets='http-request,path-parameters,request-headers,request-fields,http-response,response-headers']
+
+[[modify-reply]]
+=== 댓글 수정
+
+operation::modifyComment[snippets='http-request,path-parameters,request-headers,request-fields,http-response']

--- a/src/main/java/com/project/socket/comment/controller/ModifyCommentController.java
+++ b/src/main/java/com/project/socket/comment/controller/ModifyCommentController.java
@@ -1,0 +1,36 @@
+package com.project.socket.comment.controller;
+
+import com.project.socket.comment.controller.dto.request.ModifyCommentRequestDto;
+import com.project.socket.comment.service.usecase.ModifyCommentUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class ModifyCommentController {
+
+  private final ModifyCommentUseCase modifyCommentUseCase;
+
+  @PatchMapping("posts/{postId}/comments/{commentId}")
+  public ResponseEntity<Object> modifyComment(
+      @PathVariable @Min(1) Long postId,
+      @PathVariable @Min(1) Long commentId,
+      @RequestBody @Valid ModifyCommentRequestDto modifyCommentRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails
+  ) {
+    long userId = Long.parseLong(userDetails.getUsername());
+    modifyCommentUseCase.apply(modifyCommentRequestDto.toCommand(userId, postId, commentId));
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/project/socket/comment/controller/dto/request/ModifyCommentRequestDto.java
+++ b/src/main/java/com/project/socket/comment/controller/dto/request/ModifyCommentRequestDto.java
@@ -1,0 +1,13 @@
+package com.project.socket.comment.controller.dto.request;
+
+import com.project.socket.comment.service.usecase.ModifyCommentCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record ModifyCommentRequestDto(
+    @NotBlank String content
+) {
+
+  public ModifyCommentCommand toCommand(Long userId, Long postId, Long commentId) {
+    return new ModifyCommentCommand(userId, postId, commentId, content);
+  }
+}

--- a/src/main/java/com/project/socket/comment/exception/InvalidCommentRelationException.java
+++ b/src/main/java/com/project/socket/comment/exception/InvalidCommentRelationException.java
@@ -1,0 +1,11 @@
+package com.project.socket.comment.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class InvalidCommentRelationException extends BusinessException {
+
+  public InvalidCommentRelationException() {
+    super(ErrorCode.INVALID_COMMENT_RELATION);
+  }
+}

--- a/src/main/java/com/project/socket/comment/model/Comment.java
+++ b/src/main/java/com/project/socket/comment/model/Comment.java
@@ -60,6 +60,16 @@ public class Comment extends BaseTime {
     this.parentComment = parentComment;
   }
 
+  public boolean validateRelation(Long writerId, Long postId) {
+    return this.writer.getUserId().equals(writerId) && this.cPost.getId().equals(postId);
+
+  }
+
+  public void modifyContent(String content) {
+    this.content = content;
+    this.commentStatus = CommentStatus.MODIFIED;
+  }
+
   @Builder
   public Comment(Long id, Post cPost, User writer, String content, Comment parentComment,
       CommentStatus commentStatus) {

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
@@ -3,6 +3,6 @@ package com.project.socket.comment.repository;
 import com.project.socket.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
 }

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
@@ -3,6 +3,6 @@ package com.project.socket.comment.repository;
 import com.project.socket.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
 }

--- a/src/main/java/com/project/socket/comment/service/ModifyCommentService.java
+++ b/src/main/java/com/project/socket/comment/service/ModifyCommentService.java
@@ -1,0 +1,38 @@
+package com.project.socket.comment.service;
+
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.ModifyCommentCommand;
+import com.project.socket.comment.service.usecase.ModifyCommentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyCommentService implements ModifyCommentUseCase {
+
+  private final CommentJpaRepository commentJpaRepository;
+
+  @Transactional
+  @Override
+  public Comment apply(ModifyCommentCommand modifyCommentCommand) {
+    Comment commentToModify = findComment(modifyCommentCommand.commentId());
+
+    if (!commentToModify.validateRelation(
+        modifyCommentCommand.userId(),
+        modifyCommentCommand.postId())) {
+      throw new InvalidCommentRelationException();
+    }
+
+    commentToModify.modifyContent(modifyCommentCommand.content());
+    return commentToModify;
+  }
+
+  private Comment findComment(Long commentId) {
+    return commentJpaRepository.findById(commentId)
+                               .orElseThrow(() -> new CommentNotFoundException(commentId));
+  }
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/ModifyCommentCommand.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/ModifyCommentCommand.java
@@ -1,0 +1,10 @@
+package com.project.socket.comment.service.usecase;
+
+public record ModifyCommentCommand(
+    Long userId,
+    Long postId,
+    Long commentId,
+    String content
+) {
+
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/ModifyCommentUseCase.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/ModifyCommentUseCase.java
@@ -1,0 +1,8 @@
+package com.project.socket.comment.service.usecase;
+
+import com.project.socket.comment.model.Comment;
+import java.util.function.Function;
+
+public interface ModifyCommentUseCase extends Function<ModifyCommentCommand, Comment> {
+
+}

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
   // post
   POST_NOT_FOUND(404, "P1", "해당 포스트가 존재하지 않습니다"),
   // comment
-  COMMENT_NOT_FOUND(404, "CM1", "해당 댓글이 존재하지 않습니다");
+  COMMENT_NOT_FOUND(404, "CM1", "해당 댓글이 존재하지 않습니다"),
+  INVALID_COMMENT_RELATION(400, "CM2", "잘못된 요청입니다");
 
   private int status;
   private final String code;

--- a/src/test/java/com/project/socket/comment/controller/ModifyCommentControllerTest.java
+++ b/src/test/java/com/project/socket/comment/controller/ModifyCommentControllerTest.java
@@ -1,0 +1,145 @@
+package com.project.socket.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.comment.controller.dto.request.ModifyCommentRequestDto;
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.service.usecase.ModifyCommentUseCase;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.docs.RestDocsAttributeFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(ModifyCommentController.class)
+class ModifyCommentControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  ModifyCommentUseCase modifyCommentUseCase;
+
+  final Long POST_ID = 1L;
+  final Long COMMENT_ID = 1L;
+
+  ModifyCommentRequestDto validRequest = new ModifyCommentRequestDto("modify");
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 요청이_유효하면_성공적으로_댓글을_변경하고_200_응답을_한다() throws Exception {
+    when(modifyCommentUseCase.apply(any()))
+        .thenReturn(Comment.builder().id(1L).build());
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(validRequest)))
+           .andExpectAll(
+               status().isOk()
+           )
+           .andDo(
+               document("modifyComment",
+                   preprocessRequest(prettyPrint()),
+                   preprocessResponse(prettyPrint()),
+                   pathParameters(
+                       parameterWithName("postId").description("댓글의 포스트 ID"),
+                       parameterWithName("commentId").description("수정할 댓글 ID")
+                   ),
+                   requestHeaders(
+                       headerWithName("Authorization").description("Bearer access-token")
+                   ),
+                   requestFields(
+                       fieldWithPath("content")
+                           .type(JsonFieldType.STRING).description("수정할 댓글 내용")
+                           .attributes(RestDocsAttributeFactory.constraintsField("널 x, 공백 x"))
+                   )
+               )
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void CommentNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception{
+    when(modifyCommentUseCase.apply(any())).thenThrow(new CommentNotFoundException(1L));
+
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(validRequest)))
+           .andExpectAll(
+               status().isNotFound()
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void InvalidCommentRelationException_예외가_발생하면_400_응답을_한다() throws Exception{
+    when(modifyCommentUseCase.apply(any())).thenThrow(new InvalidCommentRelationException());
+
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(validRequest)))
+           .andExpectAll(
+               status().isBadRequest()
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void postId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", -1L, COMMENT_ID)
+               .contentType(APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(validRequest)))
+           .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void commentId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", POST_ID, -1L)
+               .contentType(APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(validRequest)))
+           .andExpect(status().isBadRequest());
+  }
+
+  @ParameterizedTest(name = "content가_{0}이면_400_응답을_한다")
+  @NullAndEmptySource
+  @ValueSource(strings = {" "})
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void ModifyCommentRequestDto_not_valid(String content) throws Exception {
+    ModifyCommentRequestDto InvalidRequest = new ModifyCommentRequestDto(content);
+
+    mockMvc.perform(patch("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .contentType(APPLICATION_JSON)
+               .content(objectMapper.writeValueAsBytes(InvalidRequest)))
+           .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/project/socket/comment/model/CommentTest.java
+++ b/src/test/java/com/project/socket/comment/model/CommentTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.project.socket.post.model.Post;
 import com.project.socket.user.model.User;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -31,6 +35,33 @@ class CommentTest {
           assertThat(comment.getCommentStatus()).isEqualTo(CommentStatus.CREATED);
           assertThat(comment.getParentComment()).isNull();
         }
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("providePostIdAndUserId")
+  void 유효한_연관관계가_아니면_false를_반환한다(Long postId, Long userId){
+    Post post = Post.builder().id(1L).build();
+    User user = User.builder().userId(1L).build();
+    Comment comment = Comment.builder().writer(user).cPost(post).build();
+
+    assertThat(comment.validateRelation(userId, postId)).isFalse();
+  }
+
+  @Test
+  void 유효한_연관관계라면_true를_반환한다(){
+    Post post = Post.builder().id(1L).build();
+    User user = User.builder().userId(1L).build();
+    Comment comment = Comment.builder().writer(user).cPost(post).build();
+
+    assertThat(comment.validateRelation(1L, 1L)).isTrue();
+  }
+
+  private static Stream<Arguments> providePostIdAndUserId(){
+    return Stream.of(
+        Arguments.of(1L, 2L),
+        Arguments.of(2L, 2L),
+        Arguments.of(2L, 1L)
     );
   }
 }

--- a/src/test/java/com/project/socket/comment/service/ModifyCommentServiceTest.java
+++ b/src/test/java/com/project/socket/comment/service/ModifyCommentServiceTest.java
@@ -1,0 +1,73 @@
+package com.project.socket.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.ModifyCommentCommand;
+import com.project.socket.post.model.Post;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ModifyCommentServiceTest {
+
+  @InjectMocks
+  ModifyCommentService modifyCommentService;
+
+  @Mock
+  CommentJpaRepository commentJpaRepository;
+
+  ModifyCommentCommand command = new ModifyCommentCommand(1L, 1L, 1L, "modify");
+
+  @Test
+  void id에_해당하는_comment가_없으면_CommentNotFoundException_예외가_발생한다() {
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> modifyCommentService.apply(command))
+        .isInstanceOf(CommentNotFoundException.class);
+  }
+
+  @Test
+  void 수정할_comment의_정보와_요청의_연관관계_검증이_실패하면_InvalidCommentRelationException_예외가_발생한다() {
+    Comment givenComment = Comment.builder().id(1L).content("previous")
+                                  .cPost(Post.builder().id(1L).build())
+                                  .writer(User.builder().userId(2L).build()).build();
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.of(givenComment));
+
+    assertThatThrownBy(() -> modifyCommentService.apply(command))
+        .isInstanceOf(InvalidCommentRelationException.class);
+  }
+
+  @Test
+  void 요청이_유효하면_성공적으로_content를_변경한다() {
+    Comment givenComment = Comment.builder().id(1L).content("previous")
+                                  .cPost(Post.builder().id(1L).build())
+                                  .commentStatus(CommentStatus.CREATED)
+                                  .writer(User.builder().userId(1L).build()).build();
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.of(givenComment));
+
+    Comment modifiedComment = modifyCommentService.apply(command);
+
+    assertAll(
+        () -> assertThat(modifiedComment.getContent()).isEqualTo(command.content()),
+        () -> assertThat(modifiedComment.getCommentStatus()).isEqualTo(CommentStatus.MODIFIED)
+    );
+  }
+
+}


### PR DESCRIPTION
## PR 요약
댓글 수정 API를 구현했습니다.
요청에 해당하는 Comment가 존재하지 않으면 CommentNotFoundException 예외가 발생하고 404 응답을 합니다.
Comment과 연관관계가 있는 user, post와 요청의 userId, postId가 맞지 않으면 InvalidCommentRelationException 예외가 발생하고 400 응답을 합니다.

요청이 성공적으로 수행되면 200 응답을하고 Body는 비어있습니다.

## 변경 사항

#### Linked Issue
close #39 