### PR TITLE
[FEAT] 댓글 삭제 기능 구현

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -12,3 +12,8 @@ operation::addReply[snippets='http-request,path-parameters,request-headers,reque
 === 댓글 수정
 
 operation::modifyComment[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
+
+[[delete-reply]]
+=== 댓글 삭제
+
+operation::deleteComment[snippets='http-request,path-parameters,request-headers,http-response']

--- a/src/main/java/com/project/socket/comment/controller/DeleteCommentController.java
+++ b/src/main/java/com/project/socket/comment/controller/DeleteCommentController.java
@@ -1,0 +1,33 @@
+package com.project.socket.comment.controller;
+
+import com.project.socket.comment.service.usecase.DeleteCommentCommand;
+import com.project.socket.comment.service.usecase.DeleteCommentUseCase;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class DeleteCommentController {
+
+  private final DeleteCommentUseCase deleteCommentUseCase;
+
+  @DeleteMapping("posts/{postId}/comments/{commentId}")
+  public ResponseEntity<Object> deleteComment(
+      @PathVariable @Min(1) Long postId,
+      @PathVariable @Min(1) Long commentId,
+      @AuthenticationPrincipal UserDetails userDetails
+  ){
+    Long userId = Long.valueOf(userDetails.getUsername());
+    deleteCommentUseCase.accept(new DeleteCommentCommand(userId, postId, commentId));
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/project/socket/comment/model/Comment.java
+++ b/src/main/java/com/project/socket/comment/model/Comment.java
@@ -70,6 +70,10 @@ public class Comment extends BaseTime {
     this.commentStatus = CommentStatus.MODIFIED;
   }
 
+  public void changeStatusToDeleted(){
+    this.commentStatus = CommentStatus.DELETED;
+  }
+
   @Builder
   public Comment(Long id, Post cPost, User writer, String content, Comment parentComment,
       CommentStatus commentStatus) {

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
@@ -3,6 +3,6 @@ package com.project.socket.comment.repository;
 import com.project.socket.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
 }

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
@@ -3,6 +3,6 @@ package com.project.socket.comment.repository;
 import com.project.socket.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
 }

--- a/src/main/java/com/project/socket/comment/service/DeleteCommentService.java
+++ b/src/main/java/com/project/socket/comment/service/DeleteCommentService.java
@@ -1,0 +1,37 @@
+package com.project.socket.comment.service;
+
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.DeleteCommentCommand;
+import com.project.socket.comment.service.usecase.DeleteCommentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteCommentService implements DeleteCommentUseCase {
+
+  private final CommentJpaRepository commentJpaRepository;
+
+  @Transactional
+  @Override
+  public void accept(DeleteCommentCommand deleteCommentCommand) {
+    Comment commentToDelete = findComment(deleteCommentCommand.commentId());
+
+    if (!commentToDelete.validateRelation(
+        deleteCommentCommand.userId(),
+        deleteCommentCommand.postId())) {
+      throw new InvalidCommentRelationException();
+    }
+
+    commentToDelete.changeStatusToDeleted();
+  }
+
+  private Comment findComment(Long commentId) {
+    return commentJpaRepository.findById(commentId)
+                               .orElseThrow(() -> new CommentNotFoundException(commentId));
+  }
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/DeleteCommentCommand.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/DeleteCommentCommand.java
@@ -1,0 +1,9 @@
+package com.project.socket.comment.service.usecase;
+
+public record DeleteCommentCommand(
+    Long userId,
+    Long postId,
+    Long commentId
+) {
+
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/DeleteCommentUseCase.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/DeleteCommentUseCase.java
@@ -1,0 +1,7 @@
+package com.project.socket.comment.service.usecase;
+
+import java.util.function.Consumer;
+
+public interface DeleteCommentUseCase extends Consumer<DeleteCommentCommand> {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,8 +12,6 @@ spring:
 logging:
   level:
     org.springframework.security: trace
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace
 
 jwt:
   secret: socket-secret-key-for-local-please

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,8 +19,6 @@ spring:
 logging:
   level:
     org.springframework.security: trace
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace
 
 server:
   shutdown: graceful

--- a/src/test/java/com/project/socket/comment/controller/DeleteCommentControllerTest.java
+++ b/src/test/java/com/project/socket/comment/controller/DeleteCommentControllerTest.java
@@ -1,0 +1,98 @@
+package com.project.socket.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.service.usecase.DeleteCommentUseCase;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(DeleteCommentController.class)
+class DeleteCommentControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  DeleteCommentUseCase deleteCommentUseCase;
+
+  final Long POST_ID = 1L;
+  final Long COMMENT_ID = 1L;
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 요청이_유효하면_204_응답을_한다() throws Exception {
+    doNothing().when(deleteCommentUseCase).accept(any());
+    mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken"))
+           .andExpect(status().is2xxSuccessful())
+           .andDo(
+               document("deleteComment",
+                   preprocessRequest(prettyPrint()),
+                   preprocessResponse(prettyPrint()),
+                   pathParameters(
+                       parameterWithName("postId").description("댓글의 포스트 ID"),
+                       parameterWithName("commentId").description("삭제할 댓글 ID")
+                   ),
+                   requestHeaders(
+                       headerWithName("Authorization").description("Bearer access-token")
+                   ))
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void postId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", -1L, COMMENT_ID))
+           .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void commentId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", POST_ID, -1L))
+           .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void CommentNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception {
+    doThrow(new CommentNotFoundException(1L)).when(deleteCommentUseCase).accept(any());
+
+    mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken"))
+           .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void InvalidCommentRelationException_예외가_발생하면_400_응답을_한다() throws Exception {
+    doThrow(new InvalidCommentRelationException()).when(deleteCommentUseCase).accept(any());
+
+    mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", POST_ID, COMMENT_ID)
+               .header("Authorization", "Bearer accessToken"))
+           .andExpect(status().isBadRequest());
+  }
+
+}

--- a/src/test/java/com/project/socket/comment/model/CommentTest.java
+++ b/src/test/java/com/project/socket/comment/model/CommentTest.java
@@ -57,6 +57,15 @@ class CommentTest {
     assertThat(comment.validateRelation(1L, 1L)).isTrue();
   }
 
+  @Test
+  void comment의_status를_DELETED로_변경한다 (){
+    Comment comment = Comment.builder().commentStatus(CommentStatus.CREATED).build();
+
+    comment.changeStatusToDeleted();
+
+    assertThat(comment.getCommentStatus()).isEqualTo(CommentStatus.DELETED);
+  }
+
   private static Stream<Arguments> providePostIdAndUserId(){
     return Stream.of(
         Arguments.of(1L, 2L),

--- a/src/test/java/com/project/socket/comment/service/DeleteCommentServiceTest.java
+++ b/src/test/java/com/project/socket/comment/service/DeleteCommentServiceTest.java
@@ -1,0 +1,68 @@
+package com.project.socket.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.comment.exception.CommentNotFoundException;
+import com.project.socket.comment.exception.InvalidCommentRelationException;
+import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.DeleteCommentCommand;
+import com.project.socket.post.model.Post;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DeleteCommentServiceTest {
+
+  @InjectMocks
+  DeleteCommentService deleteCommentService;
+
+  @Mock
+  CommentJpaRepository commentJpaRepository;
+
+  DeleteCommentCommand command = new DeleteCommentCommand(1L, 1L, 1L);
+
+  @Test
+  void id에_해당하는_comment가_없으면_CommentNotFoundException_예외가_발생한다() {
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> deleteCommentService.accept(command))
+        .isInstanceOf(CommentNotFoundException.class);
+  }
+
+  @Test
+  void 요청정보와_comment의_연관관계가_일치하지_않으면_InvalidCommentRelationException_예외가_발생한다() {
+    Comment comment = Comment.builder().id(1L).content("previous")
+                             .cPost(Post.builder().id(1L).build())
+                             .writer(User.builder().userId(2L).build()).build();
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.of(comment));
+
+    assertThatThrownBy(() -> deleteCommentService.accept(command))
+        .isInstanceOf(InvalidCommentRelationException.class);
+  }
+
+  @Test
+  void 요청이_유효하면_성공적으로_DELETED로_status를_변경한다() {
+    Comment comment = Comment.builder().id(1L).content("previous")
+                             .cPost(Post.builder().id(1L).build())
+                             .commentStatus(CommentStatus.CREATED)
+                             .writer(User.builder().userId(1L).build()).build();
+    when(commentJpaRepository.findById(anyLong())).thenReturn(Optional.of(comment));
+
+    deleteCommentService.accept(command);
+
+    assertThat(comment.getCommentStatus()).isEqualTo(CommentStatus.DELETED);
+  }
+}


### PR DESCRIPTION
## PR 요약
댓글 삭제 기능을 구현했습니다. 
로직은 앞서 구현한 댓글 수정과 비슷하게 연관관계 예외 체크, comment 존재 체크, PathParameter  검증이 수행되고 통과가 되면,
레코드를 아예 삭제하는 것이 아닌 comment Status 를 DELETED로 변경합니다. 

아래 커밋은 무시해주세요. 다음 작업부터 표시 안되게 하겠습니다!!
- 8feed19b993bb6001e5e02db67cdc7b848161742
- ac29cb965f707c9cef4bacb094d7c2fa2d478366


#### Linked Issue
close #41 