### PR TITLE
[FEAT] 포스트에 해당하는 댓글 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     sources {
-        include("**/index.adoc")
+        include("**/index.adoc","**/common/*.adoc")
     }
     baseDirFollowsSourceFile()
 }
@@ -109,8 +109,8 @@ sonar {
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
         property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
-                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/RestDocsAttributeFactory.java,' +
-                '**/SecurityTestConfig.java, **/annotaion/*, **/model/Q*.*'
+                '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/docs/*,' +
+                '**/SecurityTestConfig.java, **/annotaion/*, **/model/Q*.*, **/ApiResponseDto.java'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ sonar {
         property 'sonar.language', 'java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.binaries', 'build/classes'
-        property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/*,' +
+        property 'sonar.exclusions', '**/*Application*.java, **/*Exception*.java, **/resources/**,' +
                 '**/CommonDocController.java, **/ProblemDetailFieldDescription.java, **/docs/*,' +
                 '**/SecurityTestConfig.java, **/annotaion/*, **/model/Q*.*, **/ApiResponseDto.java'
     }

--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -17,3 +17,8 @@ operation::modifyComment[snippets='http-request,path-parameters,request-headers,
 === 댓글 삭제
 
 operation::deleteComment[snippets='http-request,path-parameters,request-headers,http-response']
+
+[[get-all-comments-of-post]]
+=== 포스트의 댓글 목록 조회
+
+operation::getAllCommentsOfPost[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/common/comment-status.adoc
+++ b/src/docs/asciidoc/common/comment-status.adoc
@@ -1,0 +1,5 @@
+:doctype: book
+:icons: font
+
+[[comment-status]]
+operation::sample-enums-response[snippets='custom-response-fields-commentStatus']

--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,36 @@
+<script>
+  function ready(callbackFunc) {
+    if (document.readyState !== 'loading') {
+      // Document is already ready, call the callback directly
+      callbackFunc();
+    } else if (document.addEventListener) {
+      // All modern browsers to register DOMContentLoaded
+      document.addEventListener('DOMContentLoaded', callbackFunc);
+    } else {
+      // Old IE browsers
+      document.attachEvent('onreadystatechange', function () {
+        if (document.readyState === 'complete') {
+          callbackFunc();
+        }
+      });
+    }
+  }
+
+  function openPopup(event) {
+
+    const target = event.target;
+    if (target.className !== "popup") {
+      return;
+    }
+
+    event.preventDefault();
+    const screenX = event.screenX;
+    const screenY = event.screenY;
+    window.open(target.href, target.text, `left=${screenX}, top=${screenY}, width=500, height=600, status=no, menubar=no, toolbar=no, resizable=no`);
+  }
+
+  ready(function () {
+    const el = document.getElementById("content");
+    el.addEventListener("click", event => openPopup(event), false);
+  });
+</script>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,6 +5,7 @@
 :toc: left
 :toclevels: 2
 :sectlinks:
+:docinfo: shared-head
 
 [[overview]]
 == Overview

--- a/src/main/java/com/project/socket/comment/controller/GetAllCommentsOfPostController.java
+++ b/src/main/java/com/project/socket/comment/controller/GetAllCommentsOfPostController.java
@@ -1,0 +1,33 @@
+package com.project.socket.comment.controller;
+
+import com.project.socket.comment.controller.dto.response.CommentOfPostResponseDto;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import com.project.socket.comment.service.usecase.GetAllCommentsOfPostUseCase;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class GetAllCommentsOfPostController {
+
+  private final GetAllCommentsOfPostUseCase getAllCommentsOfPostUseCase;
+
+  @GetMapping("/posts/{postId}/comments")
+  public ResponseEntity<Object> getAllCommentsOfPost(@PathVariable @Min(1) Long postId) {
+    Map<Long, List<CommentOfPostDto>> commentsMap = getAllCommentsOfPostUseCase.apply(postId);
+
+    List<CommentOfPostResponseDto> responseDtos =
+        commentsMap.values().stream().map(CommentOfPostResponseDto::toResponse).toList();
+
+    return ResponseEntity.ok(responseDtos);
+
+  }
+}

--- a/src/main/java/com/project/socket/comment/controller/dto/response/CommentOfPostResponseDto.java
+++ b/src/main/java/com/project/socket/comment/controller/dto/response/CommentOfPostResponseDto.java
@@ -1,0 +1,52 @@
+package com.project.socket.comment.controller.dto.response;
+
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CommentOfPostResponseDto(
+    Long commentId,
+    String content,
+    CommentStatus commentStatus,
+    LocalDateTime createdAt,
+    Long writerId,
+    String writerNickname,
+    List<ChildComment> childComments
+) {
+
+  public record ChildComment(
+      Long commentId,
+      String content,
+      CommentStatus commentStatus,
+      LocalDateTime createdAt,
+      Long writerId,
+      String writerNickname
+  ) {
+
+  }
+
+  public static CommentOfPostResponseDto toResponse(List<CommentOfPostDto> commentOfPostDtos) {
+    CommentOfPostDto parentComment = commentOfPostDtos.get(0);
+    List<ChildComment> childComments = commentOfPostDtos.stream()
+                                                        .skip(1)
+                                                        .map(dto -> new ChildComment(
+                                                            dto.getCommentId(),
+                                                            dto.getContent(),
+                                                            dto.getCommentStatus(),
+                                                            dto.getCreatedAt(),
+                                                            dto.getWriterId(),
+                                                            dto.getWriterNickname()))
+                                                        .toList();
+
+    return new CommentOfPostResponseDto(
+        parentComment.getCommentId(),
+        parentComment.getContent(),
+        parentComment.getCommentStatus(),
+        parentComment.getCreatedAt(),
+        parentComment.getWriterId(),
+        parentComment.getWriterNickname(),
+        childComments
+    );
+  }
+}

--- a/src/main/java/com/project/socket/comment/model/CommentStatus.java
+++ b/src/main/java/com/project/socket/comment/model/CommentStatus.java
@@ -1,5 +1,22 @@
 package com.project.socket.comment.model;
 
-public enum CommentStatus {
-  CREATED, MODIFIED, DELETED
+import com.project.socket.common.model.EnumType;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CommentStatus implements EnumType {
+  CREATED("생성"),
+  MODIFIED("수정"),
+  DELETED("삭제");
+
+  private final String description;
+  @Override
+  public String getName() {
+    return this.description;
+  }
+
+  @Override
+  public String getDescription() {
+    return this.name();
+  }
 }

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepository.java
@@ -3,6 +3,7 @@ package com.project.socket.comment.repository;
 import com.project.socket.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long>,
+    CommentJpaRepositoryCustom {
 
 }

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepositoryCustom.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.project.socket.comment.repository;
+
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import java.util.List;
+
+public interface CommentJpaRepositoryCustom {
+
+  List<CommentOfPostDto> findAllCommentsByPostId(Long postId);
+}

--- a/src/main/java/com/project/socket/comment/repository/CommentJpaRepositoryImpl.java
+++ b/src/main/java/com/project/socket/comment/repository/CommentJpaRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.project.socket.comment.repository;
+
+import static com.project.socket.comment.model.QComment.comment;
+import static com.project.socket.user.model.QUser.user;
+
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class CommentJpaRepositoryImpl implements CommentJpaRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  private static final String DELETED_CONTENT = "삭제된 댓글입니다";
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<CommentOfPostDto> findAllCommentsByPostId(Long postId) {
+    return jpaQueryFactory
+        .select(Projections.fields(CommentOfPostDto.class,
+            comment.id.as("commentId"),
+            comment.commentStatus
+                .when(CommentStatus.DELETED).then(DELETED_CONTENT)
+                .otherwise(comment.content).as("content"),
+            comment.commentStatus,
+            comment.parentComment.id.as("parentId"),
+            comment.createdAt,
+            comment.writer.userId.as("writerId"),
+            comment.writer.nickname.as("writerNickname")))
+        .from(comment)
+        .join(comment.writer, user)
+        .where(eqPostId(postId))
+        .orderBy(comment.parentComment.id.asc())
+        .fetch();
+  }
+
+  private BooleanExpression eqPostId(Long postId) {
+    return postId != null ? comment.cPost.id.eq(postId) : null;
+  }
+}

--- a/src/main/java/com/project/socket/comment/service/GetAllCommentsOfPostService.java
+++ b/src/main/java/com/project/socket/comment/service/GetAllCommentsOfPostService.java
@@ -1,0 +1,61 @@
+package com.project.socket.comment.service;
+
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import com.project.socket.comment.service.usecase.GetAllCommentsOfPostUseCase;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class GetAllCommentsOfPostService implements GetAllCommentsOfPostUseCase {
+
+  private final CommentJpaRepository commentJpaRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public Map<Long, List<CommentOfPostDto>> apply(Long postId) {
+    List<CommentOfPostDto> allCommentsByPostId = commentJpaRepository
+        .findAllCommentsByPostId(postId);
+
+    Map<Long, List<CommentOfPostDto>> commentsMap = covertToMap(allCommentsByPostId);
+
+    removeAllDeletedGroup(commentsMap);
+
+    return commentsMap;
+  }
+
+  // 순서 보장을 위해 LinkedHashMap 사용
+  private Map<Long, List<CommentOfPostDto>> covertToMap(List<CommentOfPostDto> comments) {
+    LinkedHashMap<Long, List<CommentOfPostDto>> linkedHashMap = new LinkedHashMap<>();
+
+    comments.forEach(commentOfPost -> {
+      if (Objects.isNull(commentOfPost.getParentId())) {
+        ArrayList<CommentOfPostDto> commentOfPostDtos = new ArrayList<>();
+        commentOfPostDtos.add(commentOfPost);
+        linkedHashMap.put(commentOfPost.getCommentId(), commentOfPostDtos);
+      } else {
+        linkedHashMap.get(commentOfPost.getParentId()).add(commentOfPost);
+      }
+    });
+
+    return linkedHashMap;
+  }
+
+  // 그룹의 댓글들이 모두 삭제된 상태면 그룹 제거
+  private void removeAllDeletedGroup(Map<Long, List<CommentOfPostDto>> commentsMap) {
+    commentsMap.entrySet().removeIf(entry -> areAllCommentsDeleted(entry.getValue()));
+  }
+
+  private boolean areAllCommentsDeleted(List<CommentOfPostDto> comments) {
+    return comments.stream()
+                   .allMatch(comment -> comment.getCommentStatus().equals(CommentStatus.DELETED));
+  }
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/CommentOfPostDto.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/CommentOfPostDto.java
@@ -1,0 +1,30 @@
+package com.project.socket.comment.service.usecase;
+
+import com.project.socket.comment.model.CommentStatus;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentOfPostDto {
+
+  private Long commentId;
+  private String content;
+  private CommentStatus commentStatus;
+  private Long parentId;
+  private LocalDateTime createdAt;
+  private Long writerId;
+  private String writerNickname;
+
+  public CommentOfPostDto(Long commentId, String content, CommentStatus commentStatus,
+      Long parentId, LocalDateTime createdAt, Long writerId, String writerNickname) {
+    this.commentId = commentId;
+    this.content = content;
+    this.commentStatus = commentStatus;
+    this.parentId = parentId;
+    this.createdAt = createdAt;
+    this.writerId = writerId;
+    this.writerNickname = writerNickname;
+  }
+}

--- a/src/main/java/com/project/socket/comment/service/usecase/GetAllCommentsOfPostUseCase.java
+++ b/src/main/java/com/project/socket/comment/service/usecase/GetAllCommentsOfPostUseCase.java
@@ -1,0 +1,10 @@
+package com.project.socket.comment.service.usecase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface GetAllCommentsOfPostUseCase extends
+    Function<Long, Map<Long, List<CommentOfPostDto>>> {
+
+}

--- a/src/main/java/com/project/socket/common/model/EnumType.java
+++ b/src/main/java/com/project/socket/common/model/EnumType.java
@@ -1,0 +1,6 @@
+package com.project.socket.common.model;
+
+public interface EnumType {
+  String getName();
+  String getDescription();
+}

--- a/src/main/java/com/project/socket/config/JacksonConfig.java
+++ b/src/main/java/com/project/socket/config/JacksonConfig.java
@@ -1,0 +1,38 @@
+package com.project.socket.config;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+
+    return builder -> {
+
+      // formatter
+      DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+      DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+      DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+      // deserializers
+      builder.deserializers(new LocalDateDeserializer(dateFormatter));
+      builder.deserializers(new LocalDateTimeDeserializer(dateTimeFormatter));
+      builder.deserializers(new LocalTimeDeserializer(timeFormatter));
+
+      // serializers
+      builder.serializers(new LocalDateSerializer(dateFormatter));
+      builder.serializers(new LocalDateTimeSerializer(dateTimeFormatter));
+      builder.serializers(new LocalTimeSerializer(timeFormatter));
+    };
+  }
+}

--- a/src/main/java/com/project/socket/config/QuerydslConfig.java
+++ b/src/main/java/com/project/socket/config/QuerydslConfig.java
@@ -1,5 +1,8 @@
 package com.project.socket.config;
 
+import com.querydsl.jpa.DefaultQueryHandler;
+import com.querydsl.jpa.Hibernate5Templates;
+import com.querydsl.jpa.QueryHandler;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -13,7 +16,16 @@ public class QuerydslConfig {
   private EntityManager entityManager;
 
   @Bean
-  public JPAQueryFactory jpaQueryFactory(){
-    return new JPAQueryFactory(entityManager);
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(new CustomHibernate5Templates(), entityManager);
   }
+
+  public static class CustomHibernate5Templates extends Hibernate5Templates {
+
+    @Override
+    public QueryHandler getQueryHandler() {
+      return DefaultQueryHandler.DEFAULT;
+    }
+  }
+
 }

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,7 +23,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @EnableWebSecurity
@@ -54,6 +54,7 @@ public class SecurityConfig {
         .formLogin(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
+            .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()
             .requestMatchers("/signup").authenticated()
             .anyRequest().authenticated())
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,6 +12,8 @@ spring:
 logging:
   level:
     org.springframework.security: trace
+    com.zaxxer.hikari: TRACE
+    com.zaxxer.hikari.HikariConfig: DEBUG
 
 jwt:
   secret: socket-secret-key-for-local-please

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,8 @@ spring:
 logging:
   level:
     org.springframework.security: trace
+    com.zaxxer.hikari: TRACE
+    com.zaxxer.hikari.HikariConfig: DEBUG
 
 server:
   shutdown: graceful

--- a/src/test/java/com/project/socket/comment/controller/GetAllCommentsOfPostControllerTest.java
+++ b/src/test/java/com/project/socket/comment/controller/GetAllCommentsOfPostControllerTest.java
@@ -1,0 +1,131 @@
+package com.project.socket.comment.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import com.project.socket.comment.service.usecase.GetAllCommentsOfPostUseCase;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.docs.DocumentLinkGenerator;
+import com.project.socket.docs.DocumentLinkGenerator.DocUrl;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(GetAllCommentsOfPostController.class)
+class GetAllCommentsOfPostControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  GetAllCommentsOfPostUseCase getAllCommentsOfPostUseCase;
+
+  final Long POST_ID = 1L;
+  final String DELETED_CONTENT = "삭제된 댓글입니다";
+
+
+  @Test
+  void 조회결과가_없으면_body가_빈_배열인_200_응답을_한다() throws Exception {
+    when(getAllCommentsOfPostUseCase.apply(anyLong())).thenReturn(Map.of());
+
+    mockMvc.perform(get("/posts/{postId}/comments", POST_ID))
+           .andExpectAll(
+               status().isOk(),
+               content().string("[]")
+           );
+  }
+
+  @Test
+  void postId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(get("/posts/{postId}/comments", -1L))
+           .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void 요청이_유효하면_포스트의_댓글_목록이_담긴_200_응답을_한다() throws Exception {
+    when(getAllCommentsOfPostUseCase.apply(anyLong())).thenReturn(createUseCaseResult());
+
+    mockMvc.perform(get("/posts/{postId}/comments", POST_ID))
+           .andExpectAll(
+               status().isOk(),
+               jsonPath("$.length()").value(3),
+
+               jsonPath("$[2].childComments").isEmpty()
+           )
+        .andDo(print())
+        .andDo(document("getAllCommentsOfPost",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("postId").description("댓글의 포스트 ID")
+            ),
+            responseFields(
+                fieldWithPath("[].commentId").type(JsonFieldType.NUMBER).description("부모 댓글 ID"),
+                fieldWithPath("[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                fieldWithPath("[].commentStatus").description(
+                    DocumentLinkGenerator.generateLinkCode(DocUrl.COMMENT_STATUS)),
+                fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("댓글 생성일"),
+                fieldWithPath("[].writerId").description("댓글 작성자 ID"),
+                fieldWithPath("[].writerNickname").description("댓글 작성자 닉네임"),
+                fieldWithPath("[].childComments[].commentId").type(JsonFieldType.NUMBER).description("자식 댓글 ID"),
+                fieldWithPath("[].childComments[].content").type(JsonFieldType.STRING).description("댓글 내용"),
+                fieldWithPath("[].childComments[].commentStatus").description(
+                    DocumentLinkGenerator.generateLinkCode(DocUrl.COMMENT_STATUS)),
+                fieldWithPath("[].childComments[].createdAt").type(JsonFieldType.STRING).description("댓글 생성일"),
+                fieldWithPath("[].childComments[].writerId").description("댓글 작성자 ID"),
+                fieldWithPath("[].childComments[].writerNickname").description("댓글 작성자 닉네임"),
+                fieldWithPath("[2].childComments").ignored()
+            )));
+
+  }
+
+  Map<Long, List<CommentOfPostDto>> createUseCaseResult() {
+    LinkedHashMap<Long, List<CommentOfPostDto>> result = new LinkedHashMap<>();
+    result.put(1L, List.of(
+        new CommentOfPostDto(1L, "content", CommentStatus.CREATED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(2L, DELETED_CONTENT, CommentStatus.DELETED, 1L, LocalDateTime.now(),
+            1L, "nickname"),
+        new CommentOfPostDto(3L, "content", CommentStatus.CREATED, 1L, LocalDateTime.now(), 1L,
+            "nickname")
+    ));
+    result.put(4L, List.of(
+        new CommentOfPostDto(4L, "content", CommentStatus.CREATED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(5L, DELETED_CONTENT, CommentStatus.DELETED, 4L, LocalDateTime.now(),
+            1L, "nickname")
+        ));
+    result.put(6L, List.of(
+        new CommentOfPostDto(6L, "content", CommentStatus.CREATED, null, LocalDateTime.now(), 1L,
+            "nickname")
+        ));
+
+    return result;
+  }
+
+}

--- a/src/test/java/com/project/socket/comment/repository/CommentJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/comment/repository/CommentJpaRepositoryTest.java
@@ -3,11 +3,13 @@ package com.project.socket.comment.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.project.socket.comment.model.Comment;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
 import com.project.socket.common.annotation.CustomDataJpaTest;
 import com.project.socket.post.model.Post;
 import com.project.socket.post.repository.PostJpaRepository;
 import com.project.socket.user.model.User;
 import com.project.socket.user.repository.UserJpaRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,8 @@ class CommentJpaRepositoryTest {
 
   @Autowired
   PostJpaRepository postJpaRepository;
+
+  final String DELETED_CONTENT = "삭제된 댓글입니다";
 
   @Test
   @Sql("saveComment.sql")
@@ -56,4 +60,38 @@ class CommentJpaRepositoryTest {
 
     assertThat(foundComment).isNotPresent();
   }
+
+  @Test
+  @Sql("findAllCommentsByPostId.sql")
+  void postId에_해당하는_댓글들을_반환한다() {
+    List<CommentOfPostDto> allCommentByPostId = commentJpaRepository.findAllCommentsByPostId(1L);
+
+    assertThat(allCommentByPostId).hasSize(8);
+  }
+
+  @Test
+  void postId에_해당하는_댓글이_없으면_빈_리스트를_반환한다() {
+    List<CommentOfPostDto> allCommentByPostId = commentJpaRepository.findAllCommentsByPostId(1L);
+
+    assertThat(allCommentByPostId).isEmpty();
+  }
+
+  @Test
+  @Sql("findAllCommentsByPostId.sql")
+  void postId가_null_이면_모든_댓글을_반환한다() {
+    List<CommentOfPostDto> allCommentByPostId = commentJpaRepository.findAllCommentsByPostId(null);
+
+    assertThat(allCommentByPostId).isNotEmpty();
+  }
+
+  @Test
+  @Sql("findAllCommentsByPostId.sql")
+  void 삭제된_댓글이면_content를_변경해_반환한다() {
+    List<CommentOfPostDto> allCommentByPostId = commentJpaRepository.findAllCommentsByPostId(1L);
+
+    assertThat(allCommentByPostId)
+        .element(2)
+        .satisfies(comment -> assertThat(comment.getContent()).isEqualTo(DELETED_CONTENT));
+  }
+
 }

--- a/src/test/java/com/project/socket/comment/service/GetAllCommentOfPostDtoServiceTest.java
+++ b/src/test/java/com/project/socket/comment/service/GetAllCommentOfPostDtoServiceTest.java
@@ -1,0 +1,83 @@
+package com.project.socket.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.comment.repository.CommentJpaRepository;
+import com.project.socket.comment.service.usecase.CommentOfPostDto;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GetAllCommentOfPostDtoServiceTest {
+
+  @InjectMocks
+  GetAllCommentsOfPostService getAllCommentsOfPostService;
+
+  @Mock
+  CommentJpaRepository commentJpaRepository;
+
+  final Long POST_ID = 1L;
+
+  @Test
+  void 조회결과가_빈_리스트면_entry가_없는_map을_반환한다() {
+    when(commentJpaRepository.findAllCommentsByPostId(POST_ID)).thenReturn(Collections.EMPTY_LIST);
+
+    Map<Long, List<CommentOfPostDto>> commentsMap = getAllCommentsOfPostService.apply(POST_ID);
+
+    assertThat(commentsMap).isEmpty();
+  }
+
+  @Test
+  void 조회결과에_모두삭제된_그룹이_있으면_그룹을_삭제하고_반환한다() {
+
+    when(commentJpaRepository.findAllCommentsByPostId(POST_ID)).thenReturn(createDtos());
+
+    Map<Long, List<CommentOfPostDto>> commentsMap = getAllCommentsOfPostService.apply(POST_ID);
+
+    commentsMap.entrySet().stream().forEach(entry -> {
+      List<CommentOfPostDto> value = entry.getValue();
+      for (CommentOfPostDto commentOfPostDto : value) {
+        System.out.println(commentOfPostDto);
+      }
+    });
+
+    assertThat(commentsMap).satisfies( map -> {
+      assertThat(map).doesNotContainKey(5L);
+      assertThat(map).doesNotContainKey(7L);
+        }
+    );
+  }
+
+  List<CommentOfPostDto> createDtos() {
+    return List.of(
+        new CommentOfPostDto(1L, "content", CommentStatus.CREATED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(4L, "content", CommentStatus.DELETED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(5L, "content", CommentStatus.DELETED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(2L, "content", CommentStatus.CREATED, 1L, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(3L, "content", CommentStatus.CREATED, 1L, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(6L, "content", CommentStatus.CREATED, 4L, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(7L, "content", CommentStatus.DELETED, null, LocalDateTime.now(), 1L,
+            "nickname"),
+        new CommentOfPostDto(8L, "content", CommentStatus.DELETED, 5L, LocalDateTime.now(), 1L,
+            "nickname")
+    );
+  }
+}

--- a/src/test/java/com/project/socket/common/annotation/CustomWebMvcTestWithRestDocs.java
+++ b/src/test/java/com/project/socket/common/annotation/CustomWebMvcTestWithRestDocs.java
@@ -1,5 +1,6 @@
 package com.project.socket.common.annotation;
 
+import com.project.socket.config.JacksonConfig;
 import com.project.socket.config.SecurityTestConfig;
 import com.project.socket.security.filter.JwtFilter;
 import java.lang.annotation.ElementType;
@@ -12,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -22,6 +24,7 @@ import org.springframework.test.context.ContextConfiguration;
 @AutoConfigureRestDocs
 @ContextConfiguration(classes = SecurityTestConfig.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
+@Import(JacksonConfig.class)
 public @interface CustomWebMvcTestWithRestDocs {
 
   @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")

--- a/src/test/java/com/project/socket/common/controller/ApiResponseDto.java
+++ b/src/test/java/com/project/socket/common/controller/ApiResponseDto.java
@@ -1,0 +1,18 @@
+package com.project.socket.common.controller;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ApiResponseDto<T> {
+  private T data;
+
+  private ApiResponseDto(T data){
+    this.data=data;
+  }
+
+  public static <T> ApiResponseDto<T> of(T data) {
+    return new ApiResponseDto<>(data);
+  }
+}

--- a/src/test/java/com/project/socket/common/controller/CommonDocController.java
+++ b/src/test/java/com/project/socket/common/controller/CommonDocController.java
@@ -1,19 +1,47 @@
 package com.project.socket.common.controller;
 
+import com.project.socket.comment.model.CommentStatus;
+import com.project.socket.common.model.EnumType;
+import com.project.socket.docs.EnumDocs;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/sample")
 public class CommonDocController {
 
-  @PostMapping("/sample/error")
+  @PostMapping("/error")
   public void sampleError(@RequestBody @Valid SampleRequest sampleRequest) {
 
   }
 
-  public record SampleRequest(@NotBlank String name, @Email String email) {}
+  @GetMapping("/enums")
+  public ApiResponseDto<EnumDocs> findEnums() {
+
+    // 문서화 하고 싶은 -> EnumDocs 클래스에 담긴 모든 Enum 값 생성
+    Map<String, String> commentStatus = getDocs(CommentStatus.values());
+
+    // 전부 담아서 반환 -> 테스트에서는 이걸 꺼내 해석하여 조각을 만들면 된다.
+    return ApiResponseDto.of(EnumDocs.builder()
+                                     .commentStatus(commentStatus)
+                                     .build());
+  }
+
+  private Map<String, String> getDocs(EnumType[] enumTypes) {
+    return Arrays.stream(enumTypes)
+                 .collect(Collectors.toMap(EnumType::getName, EnumType::getDescription));
+  }
+
+  public record SampleRequest(@NotBlank String name, @Email String email) {
+
+  }
 }

--- a/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
+++ b/src/test/java/com/project/socket/common/controller/CommonDocControllerTest.java
@@ -15,13 +15,23 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.socket.common.controller.CommonDocController.SampleRequest;
 import com.project.socket.common.error.GlobalExceptionHandler;
+import com.project.socket.docs.CustomResponseFieldsSnippet;
+import com.project.socket.docs.EnumDocs;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +39,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
@@ -77,5 +92,55 @@ class CommonDocControllerTest {
                    )
                )
            );
+  }
+
+  @Test
+  void enums() throws Exception {
+    ResultActions result = this.mockMvc.perform(get("/sample/enums")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    MvcResult mvcResult = result.andReturn();
+
+    EnumDocs enumDocs = getData(mvcResult);
+
+    result.andExpect(status().isOk())
+          .andDo(
+              document(
+                  "sample-enums-response",
+                  Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                  Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                  customResponseFields("custom-response",
+                      beneathPath("data.commentStatus").withSubsectionId("commentStatus"),
+                      attributes(key("title").value("commentStatus")),
+                      enumConvertFieldDescriptor((enumDocs.getCommentStatus()))
+                  )
+              ));
+  }
+
+  // 커스텀 템플릿 사용을 위한 함수
+  public static CustomResponseFieldsSnippet customResponseFields
+  (String type, PayloadSubsectionExtractor<?> subsectionExtractor,
+      Map<String, Object> attributes, FieldDescriptor... descriptors) {
+    return new CustomResponseFieldsSnippet(type, Arrays.asList(descriptors),
+        attributes
+        , true, subsectionExtractor);
+  }
+
+  // Map으로 넘어온 enumValue를 fieldWithPath로 변경하여 리턴
+  private static FieldDescriptor[] enumConvertFieldDescriptor(Map<String, String> enumValues) {
+    return enumValues.entrySet().stream()
+                     .map(x -> fieldWithPath(x.getKey()).description(x.getValue()))
+                     .toArray(FieldDescriptor[]::new);
+  }
+
+  // mvc result 데이터 파싱
+  private EnumDocs getData(MvcResult result) throws IOException {
+    ApiResponseDto<EnumDocs> apiResponseDto = objectMapper
+        .readValue(result.getResponse().getContentAsByteArray(),
+            new TypeReference<ApiResponseDto<EnumDocs>>() {
+            }
+        );
+    return apiResponseDto.getData();
   }
 }

--- a/src/test/java/com/project/socket/docs/CustomResponseFieldsSnippet.java
+++ b/src/test/java/com/project/socket/docs/CustomResponseFieldsSnippet.java
@@ -1,0 +1,29 @@
+package com.project.socket.docs;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.payload.AbstractFieldsSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
+
+public class CustomResponseFieldsSnippet extends AbstractFieldsSnippet {
+
+  public CustomResponseFieldsSnippet(String type, List<FieldDescriptor> descriptors,
+      Map<String, Object> attributes, boolean ignoreUndocumentedFields,
+      PayloadSubsectionExtractor<?> subsectionExtractor) {
+    super(type, descriptors, attributes, ignoreUndocumentedFields, subsectionExtractor);
+  }
+
+  @Override
+  protected MediaType getContentType(Operation operation) {
+    return operation.getResponse().getHeaders().getContentType();
+  }
+
+  @Override
+  protected byte[] getContent(Operation operation) throws IOException {
+    return operation.getResponse().getContent();
+  }
+}

--- a/src/test/java/com/project/socket/docs/DocumentLinkGenerator.java
+++ b/src/test/java/com/project/socket/docs/DocumentLinkGenerator.java
@@ -1,0 +1,20 @@
+package com.project.socket.docs;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public interface DocumentLinkGenerator {
+
+  static String generateLinkCode(DocUrl docUrl) {
+    return String.format("link:common/%s.html[%s %s,role=\"popup\"]", docUrl.pageId, docUrl.text,
+        "코드");
+  }
+
+  @RequiredArgsConstructor
+  enum DocUrl {
+    COMMENT_STATUS("comment-status", "댓글 상태");
+    private final String pageId;
+    @Getter
+    private final String text;
+  }
+}

--- a/src/test/java/com/project/socket/docs/EnumDocs.java
+++ b/src/test/java/com/project/socket/docs/EnumDocs.java
@@ -1,0 +1,16 @@
+package com.project.socket.docs;
+
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EnumDocs {
+  Map<String, String> commentStatus;
+}

--- a/src/test/resources/com/project/socket/comment/repository/findAllCommentsByPostId.sql
+++ b/src/test/resources/com/project/socket/comment/repository/findAllCommentsByPostId.sql
@@ -1,0 +1,37 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (1, 1, 1, '1', 'CREATED', now(), now(), null);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (2, 1, 1, '2', 'DELETED', now(), now(), 1);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (3, 1, 1, '3', 'DELETED', now(), now(), 1);
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (4, 1, 1, '5', 'DELETED', now(), now(), null);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (5, 1, 1, '4', 'CREATED', now(), now(), 1);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (6, 1, 1, '6', 'CREATED', now(), now(), 4);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (7, 1, 1, '7', 'CREATED', now(), now(), 4);
+
+insert into comment (comment_id, post_id, user_id, content, comment_status, created_at, modified_at,
+                     parent_id)
+VALUES (8, 1, 1, '8', 'DELETED', now(), now(), null);

--- a/src/test/resources/org/springframework/restdocs/templates/custom-response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/custom-response-fields.snippet
@@ -1,0 +1,10 @@
+{{title}}
+|===
+|코드|코드명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## PR 요약
포스트에 해당하는 댓글 조회 API를 구현했습니다.

### 비즈니스 로직
- 포스트에 해당하는 댓글이 없을시 [] 200 응답
- 댓글은 부모댓글와 여러개의 자식 댓글로 이루어져 있습니다. 댓글 조회시 부모와 자식이 모두 삭제된 상태라면 조회 목록에서 제거합니다.
- 댓글 상태가 DELETED라면 댓글 내용을 삭제된 댓글로 변경해 반환합니다.


### enum 타입을 링크 팝업형식으로 볼 수 있게 rest docs 문서 구현

## 변경 사항
Enum 타입을 rest docs 에서 link popup으로 보여주기 위한 설정이 추가되었습니다.
Hibernate 6 이상 부터 querydsl transform 메서드가 작동하지 않습니다. 이를 위해 template을 변경했습니다. 

#### Linked Issue
close #43 