### PR TITLE
[FEAT] 채팅방 생성 API 구현

### DIFF
--- a/src/docs/asciidoc/chatroom.adoc
+++ b/src/docs/asciidoc/chatroom.adoc
@@ -1,0 +1,4 @@
+[[create-chatroom]]
+=== 채팅방 생성
+
+operation::createChatRoom[snippets='http-request,path-parameters,request-headers,http-response,response-headers,response-body,response-fields']

--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -21,4 +21,4 @@ operation::deleteComment[snippets='http-request,path-parameters,request-headers,
 [[get-all-comments-of-post]]
 === 포스트의 댓글 목록 조회
 
-operation::getAllCommentsOfPost[snippets='http-request,path-parameters,http-response,response-fields']
+operation::getAllCommentsOfPost[snippets='http-request,path-parameters,http-response,response-body,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -28,3 +28,8 @@ include::comment.adoc[]
 == Post API
 
 include::post.adoc[]
+
+[[CHATROOM-API]]
+== Chat Room API
+
+include::chatroom.adoc[]

--- a/src/main/java/com/project/socket/chatroom/controller/CreateChatRoomController.java
+++ b/src/main/java/com/project/socket/chatroom/controller/CreateChatRoomController.java
@@ -1,0 +1,41 @@
+package com.project.socket.chatroom.controller;
+
+import com.project.socket.chatroom.controller.dto.response.CreateChatRoomResponse;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomCommand;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomUseCase;
+import jakarta.validation.constraints.Min;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class CreateChatRoomController {
+
+  private final CreateChatRoomUseCase createChatRoomUseCase;
+
+  @PostMapping("/posts/{postId}/chat-rooms")
+  public ResponseEntity<CreateChatRoomResponse> createChatroom(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable @Min(1) Long postId) {
+    Long userId = Long.valueOf(userDetails.getUsername());
+    ChatRoom chatRoom = createChatRoomUseCase.apply(new CreateChatRoomCommand(userId, postId));
+
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                                              .path("/{id}")
+                                              .buildAndExpand(chatRoom.getChatRoomId())
+                                              .toUri();
+
+    CreateChatRoomResponse response = new CreateChatRoomResponse(chatRoom.getChatRoomId());
+    return ResponseEntity.created(location).body(response);
+  }
+}

--- a/src/main/java/com/project/socket/chatroom/controller/dto/response/CreateChatRoomResponse.java
+++ b/src/main/java/com/project/socket/chatroom/controller/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,7 @@
+package com.project.socket.chatroom.controller.dto.response;
+
+public record CreateChatRoomResponse(
+    Long chatRoomId
+) {
+
+}

--- a/src/main/java/com/project/socket/chatroom/exception/WriterCanNotStartChatException.java
+++ b/src/main/java/com/project/socket/chatroom/exception/WriterCanNotStartChatException.java
@@ -1,0 +1,11 @@
+package com.project.socket.chatroom.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class WriterCanNotStartChatException extends BusinessException {
+
+  public WriterCanNotStartChatException() {
+    super(ErrorCode.WRITER_CAN_NOT_START_CHAT);
+  }
+}

--- a/src/main/java/com/project/socket/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/project/socket/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.project.socket.chatroom.repository;
+
+import com.project.socket.chatroom.model.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/project/socket/chatroom/service/CreateChatRoomService.java
+++ b/src/main/java/com/project/socket/chatroom/service/CreateChatRoomService.java
@@ -1,0 +1,63 @@
+package com.project.socket.chatroom.service;
+
+import com.project.socket.chatroom.exception.WriterCanNotStartChatException;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomCommand;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomUseCase;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.user.model.User;
+import com.project.socket.userchatroom.model.UserChatRoom;
+import com.project.socket.userchatroom.repository.UserChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateChatRoomService implements CreateChatRoomUseCase {
+
+  private final PostJpaRepository postJpaRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final UserChatRoomRepository userChatRoomRepository;
+
+  @Override
+  @Transactional
+  public ChatRoom apply(CreateChatRoomCommand createChatRoomCommand) {
+    Post post = findPost(createChatRoomCommand.postId());
+    checkWriterStartChat(createChatRoomCommand.applicantId(), post.getUser().getUserId());
+
+    ChatRoom chatRoomToSave = ChatRoom.builder().post(post).build();
+    ChatRoom savedChatRoom = chatRoomRepository.save(chatRoomToSave);
+
+    UserChatRoom writerChatRoom = UserChatRoom.builder()
+                                              .chatRoom(savedChatRoom)
+                                              .user(post.getUser())
+                                              .build();
+
+    UserChatRoom applicantChatRoom = UserChatRoom.builder()
+                                                 .chatRoom(savedChatRoom)
+                                                 .user(User.builder()
+                                                           .userId(
+                                                               createChatRoomCommand.applicantId())
+                                                           .build())
+                                                 .build();
+
+    userChatRoomRepository.save(writerChatRoom);
+    userChatRoomRepository.save(applicantChatRoom);
+
+    return savedChatRoom;
+  }
+
+  private Post findPost(Long postId) {
+    return postJpaRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
+  }
+
+  private void checkWriterStartChat(Long applicantId, Long writerId) {
+    if (applicantId.equals(writerId)) {
+      throw new WriterCanNotStartChatException();
+    }
+  }
+}

--- a/src/main/java/com/project/socket/chatroom/service/usecase/CreateChatRoomCommand.java
+++ b/src/main/java/com/project/socket/chatroom/service/usecase/CreateChatRoomCommand.java
@@ -1,0 +1,8 @@
+package com.project.socket.chatroom.service.usecase;
+
+public record CreateChatRoomCommand(
+    Long applicantId,
+    Long postId
+) {
+
+}

--- a/src/main/java/com/project/socket/chatroom/service/usecase/CreateChatRoomUseCase.java
+++ b/src/main/java/com/project/socket/chatroom/service/usecase/CreateChatRoomUseCase.java
@@ -1,0 +1,7 @@
+package com.project.socket.chatroom.service.usecase;
+
+import com.project.socket.chatroom.model.ChatRoom;
+import java.util.function.Function;
+
+public interface CreateChatRoomUseCase extends Function<CreateChatRoomCommand, ChatRoom> {
+}

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -21,7 +21,13 @@ public enum ErrorCode {
   POST_NOT_FOUND(404, "P1", "해당 포스트가 존재하지 않습니다"),
   // comment
   COMMENT_NOT_FOUND(404, "CM1", "해당 댓글이 존재하지 않습니다"),
-  INVALID_COMMENT_RELATION(400, "CM2", "잘못된 요청입니다");
+  INVALID_COMMENT_RELATION(400, "CM2", "잘못된 요청입니다"),
+
+  /**
+   * ChatRoom 관련 에러 코드
+   */
+  WRITER_CAN_NOT_START_CHAT(400, "CR1", "작성자는 채팅방을 생성할 수 없습니다");
+
 
   private int status;
   private final String code;

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.project.socket.security.handler.CustomAuthenticationEntryPoint;
 import com.project.socket.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.project.socket.security.oauth2.handler.OAuth2LoginFailureHandler;
 import com.project.socket.security.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.project.socket.user.model.Role;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,8 @@ public class SecurityConfig {
             .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()
             .requestMatchers("/signup").authenticated()
+            .requestMatchers(HttpMethod.POST, "/posts/{postId}/chat-rooms")
+            .hasAuthority(Role.ROLE_USER.name())
             .anyRequest().authenticated())
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/src/main/java/com/project/socket/userchatroom/model/UserChatRoom.java
+++ b/src/main/java/com/project/socket/userchatroom/model/UserChatRoom.java
@@ -1,5 +1,6 @@
-package com.project.socket.chatroom.model;
+package com.project.socket.userchatroom.model;
 
+import com.project.socket.chatroom.model.ChatRoom;
 import com.project.socket.user.model.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "user_chat_room")
-public class UserChatroom {
+public class UserChatRoom {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +33,7 @@ public class UserChatroom {
   private ChatRoom chatRoom;
 
   @Builder
-  public UserChatroom(Long userChatRoomId, User user, ChatRoom chatRoom) {
+  public UserChatRoom(Long userChatRoomId, User user, ChatRoom chatRoom) {
     this.userChatRoomId = userChatRoomId;
     this.user = user;
     this.chatRoom = chatRoom;

--- a/src/main/java/com/project/socket/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/com/project/socket/userchatroom/repository/UserChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.project.socket.userchatroom.repository;
+
+import com.project.socket.userchatroom.model.UserChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long>{
+
+}

--- a/src/test/java/com/project/socket/chatroom/controller/CreateChatRoomControllerTest.java
+++ b/src/test/java/com/project/socket/chatroom/controller/CreateChatRoomControllerTest.java
@@ -1,0 +1,108 @@
+package com.project.socket.chatroom.controller;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.chatroom.exception.WriterCanNotStartChatException;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomUseCase;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.post.exception.PostNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(CreateChatRoomController.class)
+class CreateChatRoomControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  CreateChatRoomUseCase createChatRoomUseCase;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  final Long POST_ID = 1L;
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 요청이_유효하면_201_응답을_한다() throws Exception {
+    ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
+    when(createChatRoomUseCase.apply(any())).thenReturn(chatRoom);
+
+    mockMvc.perform(
+               post("/posts/{postId}/chat-rooms", POST_ID)
+                   .header("Authorization", "Bearer access-token")
+           )
+           .andExpectAll(
+               status().isCreated(),
+               header().string("Location", containsString("chat-rooms/1")),
+               jsonPath("$.chatRoomId").value(1L)
+           )
+           .andDo(
+               document("createChatRoom",
+                   preprocessRequest(prettyPrint()),
+                   preprocessResponse(prettyPrint()),
+                   pathParameters(
+                       parameterWithName("postId").description("채팅을 시작할 추가할 포스트 ID")
+                   ),
+                   requestHeaders(
+                       headerWithName("Authorization").description("Bearer access-token")
+                   ),
+                   responseHeaders(
+                       headerWithName("Location").description("생성된 채팅방 경로")
+                   ),
+                   responseFields(
+                       fieldWithPath("chatRoomId").description("채팅방 ID")
+                   )
+               )
+           );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void postId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(post("/posts/{postId}/chat-rooms", -1L))
+           .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception {
+    when(createChatRoomUseCase.apply(any())).thenThrow(new PostNotFoundException(POST_ID));
+
+    mockMvc.perform(post("/posts/{postId}/chat-rooms", POST_ID))
+           .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void WriterCanNotStartChatException_예외가_발생하면_400_응답을_한다() throws Exception {
+    when(createChatRoomUseCase.apply(any())).thenThrow(new WriterCanNotStartChatException());
+
+    mockMvc.perform(post("/posts/{postId}/chat-rooms", POST_ID))
+           .andExpect(status().isBadRequest());
+  }
+
+}

--- a/src/test/java/com/project/socket/chatroom/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatroom/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.project.socket.chatroom.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.common.annotation.CustomDataJpaTest;
+import com.project.socket.post.model.Post;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@CustomDataJpaTest
+class ChatRoomRepositoryTest {
+
+  @Autowired
+  ChatRoomRepository chatRoomRepository;
+
+  @Test
+  @Sql("saveChatRoom.sql")
+  void ChatRoom_엔티티를_저장하고_반환한다(){
+    ChatRoom chatRoom = ChatRoom.builder().post(Post.builder().id(1L).build()).build();
+    ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+    assertThat(savedChatRoom.getChatRoomId()).isEqualTo(1L);
+  }
+}

--- a/src/test/java/com/project/socket/chatroom/service/CreateChatRoomServiceTest.java
+++ b/src/test/java/com/project/socket/chatroom/service/CreateChatRoomServiceTest.java
@@ -1,0 +1,101 @@
+package com.project.socket.chatroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.chatroom.exception.WriterCanNotStartChatException;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.chatroom.service.usecase.CreateChatRoomCommand;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.user.model.User;
+import com.project.socket.userchatroom.model.UserChatRoom;
+import com.project.socket.userchatroom.repository.UserChatRoomRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CreateChatRoomServiceTest {
+
+  @Mock
+  PostJpaRepository postJpaRepository;
+
+  @Mock
+  ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  UserChatRoomRepository userChatRoomRepository;
+
+  @InjectMocks
+  CreateChatRoomService createChatRoomService;
+
+  CreateChatRoomCommand command = new CreateChatRoomCommand(1L, 1L);
+
+  @Test
+  void postId에_해당하는_포스트가_없으면_PostNotFoundException_예외가_발생한다() {
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertAll(
+        () -> assertThatThrownBy(() -> createChatRoomService.apply(command))
+            .isInstanceOf(PostNotFoundException.class),
+        () -> verify(chatRoomRepository, never()).save(any()),
+        () -> verify(userChatRoomRepository, never()).save(any()),
+        () -> verify(userChatRoomRepository, never()).save(any())
+    );
+  }
+
+  @Test
+  void 자신의_포스트에_채팅방을_생성하면_WriterCanNotStartChatException_예외가_발생한다() {
+    Post post = Post.builder().user(User.builder().userId(1L).build()).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(post));
+
+    assertAll(
+        () -> assertThatThrownBy(() -> createChatRoomService.apply(command))
+            .isInstanceOf(WriterCanNotStartChatException.class),
+        () -> verify(chatRoomRepository, never()).save(any()),
+        () -> verify(userChatRoomRepository, never()).save(any()),
+        () -> verify(userChatRoomRepository, never()).save(any())
+    );
+  }
+
+  @Test
+  void 검증이_통과되면_성공적으로_채팅방을_생성하고_반환한다() {
+    User applicant = User.builder().userId(1L).build();
+    User writer = User.builder().userId(2L).build();
+    Post post = Post.builder().user(writer).build();
+    ChatRoom savedChatRoom = ChatRoom.builder().chatRoomId(1L).post(post).build();
+    UserChatRoom applicantChatRoom = UserChatRoom.builder().userChatRoomId(1L)
+                                                 .chatRoom(savedChatRoom)
+                                                 .user(applicant).build();
+
+    UserChatRoom writerChatRoom = UserChatRoom.builder().userChatRoomId(2L)
+                                              .chatRoom(savedChatRoom)
+                                              .user(writer).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(post));
+    when(chatRoomRepository.save(any())).thenReturn(savedChatRoom);
+
+    // save 메서드가 2번 실행되기 때문에 thenReturn에 리턴값에 원하는 순서대로 2개의 인자
+    when(userChatRoomRepository.save(any())).thenReturn(writerChatRoom, applicantChatRoom);
+
+    ChatRoom chatRoom = createChatRoomService.apply(command);
+
+    assertThat(chatRoom.getChatRoomId()).isEqualTo(1L);
+  }
+}

--- a/src/test/java/com/project/socket/userchatroom/model/UserChatRoomTest.java
+++ b/src/test/java/com/project/socket/userchatroom/model/UserChatRoomTest.java
@@ -1,4 +1,4 @@
-package com.project.socket.chatroom.model;
+package com.project.socket.userchatroom.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class UserChatroomTest {
+class UserChatRoomTest {
 
   @Test
   void 엔티티_빌더_테스트(){
-    UserChatroom userChatroom = UserChatroom.builder().userChatRoomId(1L).build();
+    UserChatRoom userChatroom = UserChatRoom.builder().userChatRoomId(1L).build();
     assertThat(userChatroom.getUserChatRoomId()).isEqualTo(1L);
   }
 }

--- a/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
+++ b/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.project.socket.userchatroom.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.common.annotation.CustomDataJpaTest;
+import com.project.socket.user.model.User;
+import com.project.socket.userchatroom.model.UserChatRoom;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@CustomDataJpaTest
+class UserChatRoomRepositoryTest {
+
+  @Autowired
+  UserChatRoomRepository userChatRoomRepository;
+
+  @Test
+  @Sql("saveUserChatRoom.sql")
+  void UserChatRoom_엔티티를_저장하고_반환한다() {
+    UserChatRoom userChatRoom = UserChatRoom.builder()
+                                            .user(User.builder().userId(1L).build())
+                                            .chatRoom(ChatRoom.builder().chatRoomId(1L).build())
+                                            .build();
+    UserChatRoom savedUserChatRoom = userChatRoomRepository.save(userChatRoom);
+
+    assertThat(savedUserChatRoom.getUserChatRoomId()).isEqualTo(1L);
+  }
+}

--- a/src/test/resources/com/project/socket/chatroom/repository/saveChatRoom.sql
+++ b/src/test/resources/com/project/socket/chatroom/repository/saveChatRoom.sql
@@ -1,0 +1,6 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');

--- a/src/test/resources/com/project/socket/userchatroom/repository/saveUserChatRoom.sql
+++ b/src/test/resources/com/project/socket/userchatroom/repository/saveUserChatRoom.sql
@@ -1,0 +1,9 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into chat_room(chat_room_id, post_id)
+values (1, 1);


### PR DESCRIPTION
## PR 요약
포스트에서 작성자와 채팅을 시작하기 위한 채팅방 생성 API를 구현했습니다.
채팅방을 생성하려는 포스트의 존재 여부, 포스트 작성자 자신이 채팅방을 시작하려할 때의 검증을 추가했습니다.
하지만 테스트 후 같은 지원자에 대해 채팅방이 여러개 생성되는 문제가 있어서 중복 검증에 대한 로직을 바로 추가할 예정입니다.
확인해주시고 문제있으면 말씀해주세요!

#### Linked Issue
close #49 