### PR TITLE
[FEAT] STOMP를 이용한 채팅 메세지 전송 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //STOMP
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/project/socket/chatmessage/controller/SendChatMessageController.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/SendChatMessageController.java
@@ -1,0 +1,28 @@
+package com.project.socket.chatmessage.controller;
+
+import com.project.socket.chatmessage.controller.dto.request.SendChatMessageRequest;
+import com.project.socket.chatmessage.controller.dto.response.SendChatMessageResponse;
+import com.project.socket.chatmessage.model.ChatMessage;
+import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@RequiredArgsConstructor
+@Controller
+public class SendChatMessageController {
+
+  private final SimpMessagingTemplate simpMessagingTemplate;
+  private final SendChatMessageUseCase sendChatMessageUseCase;
+
+  @MessageMapping("/rooms/{roomId}")
+  public void sendMessage(@DestinationVariable Long roomId,
+      SendChatMessageRequest sendChatMessageRequest) {
+    ChatMessage chatMessage = sendChatMessageUseCase.sendChatMessage(
+        sendChatMessageRequest.toCommand(roomId));
+    SendChatMessageResponse response = SendChatMessageResponse.from(chatMessage);
+    simpMessagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/controller/dto/request/SendChatMessageRequest.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/dto/request/SendChatMessageRequest.java
@@ -1,0 +1,14 @@
+package com.project.socket.chatmessage.controller.dto.request;
+
+import com.project.socket.chatmessage.service.usecase.SendChatMessageCommand;
+
+public record SendChatMessageRequest(
+    Long receiverId,
+    Long senderId,
+    String content
+) {
+
+  public SendChatMessageCommand toCommand(Long chatRoomId) {
+    return new SendChatMessageCommand(chatRoomId, senderId, receiverId, content);
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/controller/dto/response/SendChatMessageResponse.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/dto/response/SendChatMessageResponse.java
@@ -1,0 +1,20 @@
+package com.project.socket.chatmessage.controller.dto.response;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+import java.time.LocalDateTime;
+
+public record SendChatMessageResponse(
+    Long chatMessageId,
+    String content,
+    Long senderId,
+    LocalDateTime createdAt,
+    Long chatRoomId,
+    int readCount
+) {
+
+  public static SendChatMessageResponse from(ChatMessage chatMessage) {
+    return new SendChatMessageResponse(chatMessage.getChatMessageId(), chatMessage.getContent(),
+        chatMessage.getSender().getUserId(), chatMessage.getCreatedAt(),
+        chatMessage.getChatRoom().getChatRoomId(), chatMessage.getReadCount());
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/model/ChatMessage.java
+++ b/src/main/java/com/project/socket/chatmessage/model/ChatMessage.java
@@ -32,7 +32,7 @@ public class ChatMessage extends BaseCreatedTime {
 
   @ManyToOne
   @JoinColumn(name = "sender_id")
-  private User user;
+  private User sender;
 
   @Column
   private String content;
@@ -41,11 +41,11 @@ public class ChatMessage extends BaseCreatedTime {
   private int readCount;
 
   @Builder
-  public ChatMessage(Long chatMessageId, ChatRoom chatRoom, User user, String content,
+  public ChatMessage(Long chatMessageId, ChatRoom chatRoom, User sender, String content,
       int readCount) {
     this.chatMessageId = chatMessageId;
     this.chatRoom = chatRoom;
-    this.user = user;
+    this.sender = sender;
     this.content = content;
     this.readCount = readCount;
   }

--- a/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.project.socket.chatmessage.repository;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+}

--- a/src/main/java/com/project/socket/chatmessage/service/SendChatMessageService.java
+++ b/src/main/java/com/project/socket/chatmessage/service/SendChatMessageService.java
@@ -1,0 +1,45 @@
+package com.project.socket.chatmessage.service;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+import com.project.socket.chatmessage.repository.ChatMessageRepository;
+import com.project.socket.chatmessage.service.usecase.SendChatMessageCommand;
+import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
+import com.project.socket.chatroom.exception.ChatRoomNotFoundException;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.user.exception.UserNotFoundException;
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SendChatMessageService implements SendChatMessageUseCase {
+
+  private final ChatMessageRepository chatMessageRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final UserJpaRepository userJpaRepository;
+
+  @Override
+  public ChatMessage sendChatMessage(SendChatMessageCommand command) {
+    ChatRoom chatRoom = findChatRoom(command.chatRoomId());
+    User sender = findSender(command.senderId());
+
+    ChatMessage chatMessage = ChatMessage.builder().chatRoom(chatRoom).readCount(1)
+                                         .content(command.content()).sender(sender)
+                                         .build();
+
+    return chatMessageRepository.save(chatMessage);
+  }
+
+  private ChatRoom findChatRoom(Long chatRoomId) {
+    return chatRoomRepository.findById(chatRoomId)
+                             .orElseThrow(() -> new ChatRoomNotFoundException(chatRoomId));
+  }
+
+  private User findSender(Long senderId) {
+    return userJpaRepository.findById(senderId)
+                            .orElseThrow(() -> new UserNotFoundException(senderId));
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/service/usecase/SendChatMessageCommand.java
+++ b/src/main/java/com/project/socket/chatmessage/service/usecase/SendChatMessageCommand.java
@@ -1,0 +1,10 @@
+package com.project.socket.chatmessage.service.usecase;
+
+public record SendChatMessageCommand(
+    Long chatRoomId,
+    Long senderId,
+    Long receiverId,
+    String content
+) {
+
+}

--- a/src/main/java/com/project/socket/chatmessage/service/usecase/SendChatMessageUseCase.java
+++ b/src/main/java/com/project/socket/chatmessage/service/usecase/SendChatMessageUseCase.java
@@ -1,0 +1,8 @@
+package com.project.socket.chatmessage.service.usecase;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+
+public interface SendChatMessageUseCase {
+
+  ChatMessage sendChatMessage(SendChatMessageCommand command);
+}

--- a/src/main/java/com/project/socket/chatroom/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/project/socket/chatroom/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,12 @@
+package com.project.socket.chatroom.exception;
+
+import static com.project.socket.common.error.ErrorCode.CHAT_ROOM_NOT_FOUND;
+
+import com.project.socket.common.error.exception.BusinessException;
+
+public class ChatRoomNotFoundException extends BusinessException {
+
+  public ChatRoomNotFoundException(Long chatRoomId) {
+    super("ChatRoom ID: " + chatRoomId, CHAT_ROOM_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
   /**
    * ChatRoom 관련 에러 코드
    */
-  WRITER_CAN_NOT_START_CHAT(400, "CR1", "작성자는 채팅방을 생성할 수 없습니다");
+  WRITER_CAN_NOT_START_CHAT(400, "CR1", "작성자는 채팅방을 생성할 수 없습니다"),
+  CHAT_ROOM_NOT_FOUND(404, "CR2", "해당 채팅방이 존재하지 않습니다");
 
 
   private int status;

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
         .formLogin(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
+            .requestMatchers("/ws/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()
             .requestMatchers("/signup").authenticated()
             .requestMatchers(HttpMethod.POST, "/posts/{postId}/chat-rooms")
@@ -73,7 +74,7 @@ public class SecurityConfig {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration corsConfiguration = new CorsConfiguration();
-    corsConfiguration.setAllowedOrigins(corsOrigins);
+    corsConfiguration.setAllowedOriginPatterns(corsOrigins);
     corsConfiguration.setAllowedHeaders(List.of("*"));
     corsConfiguration.setMaxAge(3600L);
     corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "DELETE", "PUT", "PATCH"));

--- a/src/main/java/com/project/socket/config/WebSocketConfig.java
+++ b/src/main/java/com/project/socket/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.project.socket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/sub");
+    registry.setApplicationDestinationPrefixes("/pub");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws/chat")
+            .setAllowedOriginPatterns("*");
+  }
+}

--- a/src/test/java/com/project/socket/chatmessage/controller/SendChatMessageControllerTest.java
+++ b/src/test/java/com/project/socket/chatmessage/controller/SendChatMessageControllerTest.java
@@ -1,0 +1,108 @@
+package com.project.socket.chatmessage.controller;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.chatmessage.controller.dto.request.SendChatMessageRequest;
+import com.project.socket.chatmessage.model.ChatMessage;
+import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.user.model.User;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SendChatMessageControllerTest {
+
+  @LocalServerPort
+  private int port;
+  private String URL;
+  private WebSocketStompClient stompClient;
+  @MockBean
+  private SendChatMessageUseCase sendChatMessageUseCase;
+  private static final String SEND_MESSAGE_ENDPOINT = "/pub/rooms/";
+  private static final String SUBSCRIBE_CHAT_ROOM_ENDPOINT = "/sub/rooms/";
+
+  @BeforeEach
+  void setup() {
+    URL = "ws://localhost:" + port + "/ws/chat";
+    stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+  }
+
+  @Test
+  void 메세지를_발행하면_endpoint를_구독하는_클라이언트에게_전송된다() throws Exception {
+    final Long ROOM_ID = 1L;
+    StompSession stompSession = stompClient.connectAsync(URL, new StompSessionHandlerAdapter() {
+    }).get(1, SECONDS);
+
+    MessageFrameHandler<byte[]> handler = new MessageFrameHandler<>(
+        byte[].class);
+
+    ChatMessage givenMessage = createChatMessage();
+    when(sendChatMessageUseCase.sendChatMessage(any())).thenReturn(givenMessage);
+
+    stompSession.subscribe(SUBSCRIBE_CHAT_ROOM_ENDPOINT + ROOM_ID, handler);
+    stompSession.send(SEND_MESSAGE_ENDPOINT + ROOM_ID, new SendChatMessageRequest(2L, 1L, "hi"));
+
+    byte[] chatMessageByte = handler.completableFuture.get(10, SECONDS);
+    String json = new String(chatMessageByte);
+
+    assertThat(json).contains("hi");
+  }
+
+  private class MessageFrameHandler<T> implements StompFrameHandler {
+
+    private final CompletableFuture<T> completableFuture = new CompletableFuture<>();
+
+    private final Class<T> tClass;
+
+    public MessageFrameHandler(Class<T> tClass) {
+      this.tClass = tClass;
+    }
+
+    @Override
+    public Type getPayloadType(StompHeaders headers) {
+      return tClass;
+    }
+
+    @Override
+    public void handleFrame(StompHeaders headers, Object payload) {
+      completableFuture.complete((T) payload);
+    }
+  }
+
+  ChatMessage createChatMessage() throws Exception {
+    ChatMessage givenMessage = ChatMessage.builder().chatMessageId(1L).readCount(1).content("hi")
+                                          .chatRoom(ChatRoom.builder().chatRoomId(1L).build())
+                                          .sender(
+                                              User.builder().userId(1L).build()).build();
+
+    Field createdAtField = givenMessage.getClass().getSuperclass().getDeclaredField("createdAt");
+    createdAtField.setAccessible(true);
+    createdAtField.set(givenMessage, LocalDateTime.now());
+    return givenMessage;
+  }
+}

--- a/src/test/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.project.socket.chatmessage.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.common.annotation.CustomDataJpaTest;
+import com.project.socket.user.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@CustomDataJpaTest
+class ChatMessageRepositoryTest {
+
+  @Autowired
+  ChatMessageRepository chatMessageRepository;
+
+  @Test
+  @Sql("chatMessageTest.sql")
+  void ChatMessage_엔티티를_저장하고_반환한다(){
+    ChatMessage chatMessage = ChatMessage.builder().sender(User.builder().userId(1L).build())
+                                .chatRoom(ChatRoom.builder().chatRoomId(1L).build()).content("hi")
+                                .build();
+
+    ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+
+    assertThat(savedChatMessage.getChatMessageId()).isNotNull();
+  }
+}

--- a/src/test/java/com/project/socket/chatmessage/service/SendChatMessageServiceTest.java
+++ b/src/test/java/com/project/socket/chatmessage/service/SendChatMessageServiceTest.java
@@ -1,0 +1,76 @@
+package com.project.socket.chatmessage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.chatmessage.model.ChatMessage;
+import com.project.socket.chatmessage.repository.ChatMessageRepository;
+import com.project.socket.chatmessage.service.usecase.SendChatMessageCommand;
+import com.project.socket.chatroom.exception.ChatRoomNotFoundException;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.user.exception.UserNotFoundException;
+import com.project.socket.user.model.User;
+import com.project.socket.user.repository.UserJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SendChatMessageServiceTest {
+
+  @Mock
+  UserJpaRepository userJpaRepository;
+
+  @Mock
+  ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  ChatMessageRepository chatMessageRepository;
+
+  @InjectMocks
+  SendChatMessageService sendChatMessageService;
+
+  SendChatMessageCommand command = new SendChatMessageCommand(1L, 1L, 2L, "HI");
+
+  @Test
+  void id에_해당하는_chatroom이_없으면_ChatRoomNotFoundException_예외가_발생한다() {
+    when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> sendChatMessageService.sendChatMessage(command))
+        .isInstanceOf(ChatRoomNotFoundException.class);
+  }
+
+  @Test
+  void id에_해당하는_sender가_없으면_UserNotFoundException_예외가_발생한다() {
+    ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
+    when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> sendChatMessageService.sendChatMessage(command))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void 성공적으로_ChatMessage를_저장하고_반환한다() {
+    ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
+    User sender = User.builder().userId(1L).build();
+    ChatMessage chatMessage = ChatMessage.builder().chatMessageId(1L).chatRoom(chatRoom)
+                                         .sender(sender)
+                                         .build();
+    when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(sender));
+    when(chatMessageRepository.save(any())).thenReturn(chatMessage);
+
+    ChatMessage savedChatMessage = sendChatMessageService.sendChatMessage(command);
+
+    assertThat(savedChatMessage.getChatMessageId()).isEqualTo(chatMessage.getChatMessageId());
+  }
+}

--- a/src/test/java/com/project/socket/chatroom/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatroom/repository/ChatRoomRepositoryTest.java
@@ -21,6 +21,6 @@ class ChatRoomRepositoryTest {
     ChatRoom chatRoom = ChatRoom.builder().post(Post.builder().id(1L).build()).build();
     ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
-    assertThat(savedChatRoom.getChatRoomId()).isEqualTo(1L);
+    assertThat(savedChatRoom.getChatRoomId()).isNotNull();
   }
 }

--- a/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
+++ b/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
@@ -27,7 +27,7 @@ class UserChatRoomRepositoryTest {
                                             .build();
     UserChatRoom savedUserChatRoom = userChatRoomRepository.save(userChatRoom);
 
-    assertThat(savedUserChatRoom.getUserChatRoomId()).isEqualTo(1L);
+    assertThat(savedUserChatRoom.getUserChatRoomId()).isNotNull();
   }
 
   @Test

--- a/src/test/resources/com/project/socket/chatmessage/repository/chatMessageTest.sql
+++ b/src/test/resources/com/project/socket/chatmessage/repository/chatMessageTest.sql
@@ -1,0 +1,19 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (2, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into chat_room(chat_room_id, post_id)
+values (1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id)
+values (1, 1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id)
+values (2, 2, 1);


### PR DESCRIPTION
## PR 요약
STOMP 를 이용한 채팅 메세지 전송을 구현했습니다. 
STOMP란 WebSocket 위에서 동작하는 간단한 텍스트기반 메시지 프로토콜로, 클라이언트와 서버가 전송할 메시지의 유형, 형식, 내용들을 정의하고 WebSocket의 특징인 연결지향적, 실시간성, 양방향 통신의 특징을 모두 지니고 있습니다.
메시지 브로커를 활용하여 pub-sub(발행-구독) 방식으로 클라이언트와 서버가 쉽게 메시지를 주고받을 수 있도록하는 프로토콜로 볼 수 있습니다.

현재는 어플리케이션 내부 메모리를 이용해 메세지 브로커가 작동하지만 다중 서버나 메세지 유실 등을 고려하면 외부 메세지 브로커 추가가 필요해 보입니다.

읽음 안읽음 기능 구현은 이후에 추가적인 작업이 필요합니다.

## 변경 사항
STOMP 의존성 추가, 

#### Linked Issue
close #53 