### PR TITLE
[FEAT] 추가 정보 입력시 profileSetup 변경 로직 추가

### DIFF
--- a/src/main/java/com/project/socket/user/model/User.java
+++ b/src/main/java/com/project/socket/user/model/User.java
@@ -62,5 +62,6 @@ public class User extends BaseTime {
   public void updateAdditionalInfo(String nickname, String githubLink) {
     this.nickname = nickname;
     this.githubLink = githubLink;
+    this.profileSetup = true;
   }
 }

--- a/src/test/java/com/project/socket/user/service/SignupServiceTest.java
+++ b/src/test/java/com/project/socket/user/service/SignupServiceTest.java
@@ -2,7 +2,7 @@ package com.project.socket.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -67,7 +67,8 @@ class SignupServiceTest {
     User updatedUser = signupService.signup(command);
     assertAll(
         () -> assertThat(updatedUser.getGithubLink()).isEqualTo(command.githubLink()),
-        () -> assertThat(updatedUser.getNickname()).isEqualTo(command.nickname())
+        () -> assertThat(updatedUser.getNickname()).isEqualTo(command.nickname()),
+        () -> assertThat(updatedUser.isProfileSetup()).isTrue()
     );
   }
 


### PR DESCRIPTION
## PR 요약
추가 정보를 입력해 회원가입 완료시 ProfileSetup을 true로 변경하는 로직과 테스트케이스를 추가했습니다

#### Linked Issue
close #54 