### PR TITLE
게시물 수정 기능 구현

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -2,3 +2,8 @@
 === 포스트 추가
 
 operation::savePost[snippets='http-request,request-headers,request-fields,http-response,response-headers']
+
+[[modify-post]]
+=== 포스트 수정
+
+operation::modifyPost[snippets='http-request,path-parameters,request-headers,request-fields,http-response']

--- a/src/main/java/com/project/socket/common/ModifyInputValidCheck/StringInputCheck.java
+++ b/src/main/java/com/project/socket/common/ModifyInputValidCheck/StringInputCheck.java
@@ -1,0 +1,20 @@
+package com.project.socket.common.ModifyInputValidCheck;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Constraint(validatedBy = StringModifyInputCheck.class)
+public @interface StringInputCheck {
+
+  String message() default "Invalid string type input value";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/project/socket/common/ModifyInputValidCheck/StringModifyInputCheck.java
+++ b/src/main/java/com/project/socket/common/ModifyInputValidCheck/StringModifyInputCheck.java
@@ -1,0 +1,19 @@
+package com.project.socket.common.ModifyInputValidCheck;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringModifyInputCheck implements ConstraintValidator<StringInputCheck, String> {
+
+  @Override
+  public void initialize(StringInputCheck constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return value == null || value.trim().length() > 0;
+
+  }
+}

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
   // post
   POST_NOT_FOUND(404, "P1", "해당 포스트가 존재하지 않습니다"),
+  INVALID_POST_RELATION(400, "P2", "잘못된 요청 입니다"),
   // comment
   COMMENT_NOT_FOUND(404, "CM1", "해당 댓글이 존재하지 않습니다"),
   INVALID_COMMENT_RELATION(400, "CM2", "잘못된 요청입니다");

--- a/src/main/java/com/project/socket/post/controller/PostModifyController.java
+++ b/src/main/java/com/project/socket/post/controller/PostModifyController.java
@@ -1,0 +1,39 @@
+package com.project.socket.post.controller;
+
+import com.project.socket.post.controller.dto.request.PostModifyRequestDto;
+import com.project.socket.post.service.usecase.PostModifyUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@Valid
+public class PostModifyController {
+
+  private final PostModifyUseCase postModifyUseCase;
+
+  @PatchMapping("posts/{postId}")
+  public ResponseEntity<Object> modifyPost(
+      @PathVariable @Min(1) Long postId,
+      @RequestBody @Validated PostModifyRequestDto postModifyRequestDto,
+      @AuthenticationPrincipal UserDetails userDetails
+  ) {
+    long userId = Long.parseLong(userDetails.getUsername());
+
+    postModifyUseCase.modifyPostNew(postModifyRequestDto.toCommand(userId, postId));
+
+    return ResponseEntity.ok().build();
+  }
+
+
+}

--- a/src/main/java/com/project/socket/post/controller/dto/request/PostModifyRequestDto.java
+++ b/src/main/java/com/project/socket/post/controller/dto/request/PostModifyRequestDto.java
@@ -1,0 +1,19 @@
+package com.project.socket.post.controller.dto.request;
+
+import com.project.socket.common.ModifyInputValidCheck.StringInputCheck;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.service.usecase.PostModifyCommand;
+
+public record PostModifyRequestDto(@StringInputCheck String title,
+                                   @StringInputCheck String postContent,
+                                   PostType postType,
+                                   PostMeeting postMeeting) {
+
+
+  public PostModifyCommand toCommand(Long userId, Long postId) {
+    return new PostModifyCommand(userId, postId, title, postContent, postType, postMeeting);
+  }
+
+
+}

--- a/src/main/java/com/project/socket/post/exception/InvalidPostRelationException.java
+++ b/src/main/java/com/project/socket/post/exception/InvalidPostRelationException.java
@@ -1,0 +1,11 @@
+package com.project.socket.post.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class InvalidPostRelationException extends BusinessException {
+
+  public InvalidPostRelationException() {
+    super(ErrorCode.INVALID_POST_RELATION);
+  }
+}

--- a/src/main/java/com/project/socket/post/model/Post.java
+++ b/src/main/java/com/project/socket/post/model/Post.java
@@ -79,4 +79,26 @@ public class Post extends BaseTime {
   }
 
 
+  public boolean validatePostRelation(Long userId) {
+    return this.user.getUserId().equals(userId);
+  }
+
+  public void modifyInfo(Post modifiedEntity) {
+    if ((modifiedEntity.title != null)) {
+      this.title = modifiedEntity.title;
+    }
+    if (modifiedEntity.postContent != null) {
+      this.postContent = modifiedEntity.postContent;
+    }
+    if (modifiedEntity.postType != null) {
+      this.postType = modifiedEntity.postType;
+    }
+    if (modifiedEntity.postMeeting != null) {
+      this.postMeeting = modifiedEntity.postMeeting;
+    }
+    this.postStatus = PostStatus.MODIFIED;
+
+  }
+
+
 }

--- a/src/main/java/com/project/socket/post/service/PostModifyService.java
+++ b/src/main/java/com/project/socket/post/service/PostModifyService.java
@@ -1,0 +1,39 @@
+package com.project.socket.post.service;
+
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostModifyCommand;
+import com.project.socket.post.service.usecase.PostModifyUseCase;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostModifyService implements PostModifyUseCase {
+
+  private final PostJpaRepository postJpaRepository;
+
+
+  @Transactional
+  @Override
+  public Post modifyPostNew(PostModifyCommand postModifyCommand) {
+    Post postToModify = findPost(postModifyCommand.postId());
+
+    if (!postToModify.validatePostRelation(
+        postModifyCommand.userId())) {
+      throw new InvalidPostRelationException();
+    }
+
+    postToModify.modifyInfo(postModifyCommand.toModifiedEntity());
+    return postToModify;
+  }
+
+  private Post findPost(Long postId) {
+    return postJpaRepository.findById(postId)
+        .orElseThrow(() -> new PostNotFoundException(postId));
+  }
+}

--- a/src/main/java/com/project/socket/post/service/usecase/PostModifyCommand.java
+++ b/src/main/java/com/project/socket/post/service/usecase/PostModifyCommand.java
@@ -1,0 +1,31 @@
+package com.project.socket.post.service.usecase;
+
+import com.project.socket.post.model.Post;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostType;
+
+public record PostModifyCommand(
+
+    Long userId,
+
+    Long postId,
+
+    String title,
+
+    String postContent,
+
+    PostType postType,
+
+    PostMeeting postMeeting
+) {
+
+  public Post toModifiedEntity() {
+    return Post.builder()
+        .title(title)
+        .postContent(postContent)
+        .postType(postType)
+        .postMeeting(postMeeting)
+        .build();
+  }
+
+}

--- a/src/main/java/com/project/socket/post/service/usecase/PostModifyUseCase.java
+++ b/src/main/java/com/project/socket/post/service/usecase/PostModifyUseCase.java
@@ -1,0 +1,11 @@
+package com.project.socket.post.service.usecase;
+
+import com.project.socket.post.model.Post;
+import jakarta.transaction.Transactional;
+
+public interface PostModifyUseCase {
+
+  @Transactional
+  Post modifyPostNew(PostModifyCommand postModifyCommand);
+
+}

--- a/src/test/java/com/project/socket/post/controller/PostModifyControllerTest.java
+++ b/src/test/java/com/project/socket/post/controller/PostModifyControllerTest.java
@@ -1,0 +1,223 @@
+package com.project.socket.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.docs.RestDocsAttributeFactory;
+import com.project.socket.post.controller.dto.request.PostModifyRequestDto;
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.service.usecase.PostModifyUseCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(PostModifyController.class)
+public class PostModifyControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  PostModifyUseCase postModifyUseCase;
+
+  final Long POST_ID = 1L;
+
+
+  PostModifyRequestDto validRequest = new PostModifyRequestDto("modifyTitle", "modifyPostContent",
+      PostType.STUDY, PostMeeting.ON_OFFLINE);
+
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 요청이_유효하면_성공적으로_게시물_변경하고_200_응답을_한다() throws Exception {
+    when(postModifyUseCase.modifyPostNew(any())).thenReturn(Post.builder().id(1L).build());
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(validRequest)))
+        .andExpectAll(
+            status().isOk()
+        )
+        .andDo(
+            document("modifyPost",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("postId").description("수정할 포스트 ID")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("Bearer access-token")
+                ),
+                requestFields(
+                    fieldWithPath("title")
+                        .type(JsonFieldType.STRING).description("수정할 게시물 제목")
+                        .attributes(RestDocsAttributeFactory.constraintsField("널 O, 공백 x")),
+                    fieldWithPath("postContent")
+                        .type(JsonFieldType.STRING).description("수정할 게시물 내용")
+                        .attributes(RestDocsAttributeFactory.constraintsField("널 O, 공백 x")),
+                    fieldWithPath("postType")
+                        .type(JsonFieldType.STRING).description("수정할 PROJECT/STUDY")
+                        .attributes(RestDocsAttributeFactory.constraintsField("널 O, 공백 x")),
+                    fieldWithPath("postMeeting")
+                        .type(JsonFieldType.STRING).description("수정할 ONLINE/OFFLINE/ON_OFFLINE")
+                        .attributes(RestDocsAttributeFactory.constraintsField("널 O, 공백 x"))
+                )
+            )
+        );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception {
+    when(postModifyUseCase.modifyPostNew(any())).thenThrow(new PostNotFoundException(1L));
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(validRequest)))
+        .andExpectAll(
+            status().isNotFound()
+        );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void InvalidPostRelationException_예외가_발생하면_400_응답을_한다() throws Exception {
+    when(postModifyUseCase.modifyPostNew(any())).thenThrow(new InvalidPostRelationException());
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(validRequest)))
+        .andExpectAll(
+            status().isBadRequest()
+        );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void postId_parameter가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(patch("/posts/{postId}", -1L)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(validRequest)))
+        .andExpect(status().isBadRequest());
+
+  }
+
+  @ParameterizedTest(name = "변경한_title이_{0}이면_400_응답을_한다")
+  @EmptySource
+  @ValueSource(strings = {" "})
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_title_not_valid(String title) throws Exception {
+
+    PostModifyRequestDto requestBody = new PostModifyRequestDto(title, "test_postContent",
+        PostType.PROJECT,
+        PostMeeting.ONLINE);
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(requestBody)))
+        .andExpect(status().isBadRequest())
+        .andDo(print());
+  }
+
+  @ParameterizedTest(name = "변경한_postContent가_{0}이면_400_응답을_한다")
+  @EmptySource
+  @ValueSource(strings = {" "})
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_postContent_not_valid(String postContent) throws Exception {
+
+    PostModifyRequestDto requestBody = new PostModifyRequestDto("test_title", postContent,
+        PostType.PROJECT, PostMeeting.ONLINE);
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsBytes(requestBody)))
+        .andExpect(status().isBadRequest())
+        .andDo(print());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_postType_isEmpty_not_valid_400_응답을_한다() throws Exception {
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(
+                "{\"title\":\"test_title\",\"postContent\":\"test_postContent\",\"postType\":\"\",\"postMeeting\":\"ONLINE\"}"
+            )
+        )
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_postType_isBlank_not_valid_400_응답을_한다() throws Exception {
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(
+                "{\"title\":\"test_title\",\"postContent\":\"test_postContent\",\"postType\":\" \",\"postMeeting\":\"ONLINE\"}"
+            )
+        )
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_postMeeting_isEmpty_not_valid_400_응답을_한다() throws Exception {
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(
+                "{\"title\":\"test_title\",\"postContent\":\"test_postContent\",\"postType\":\"PROJECT\",\"postMeeting\":\"\"}"
+            )
+        )
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostModifyRequestDto_postMeeting_isBlank_not_valid_400_응답을_한다() throws Exception {
+
+    mockMvc.perform(patch("/posts/{postId}", POST_ID)
+            .contentType(APPLICATION_JSON)
+            .content(
+                "{\"title\":\"test_title\",\"postContent\":\"test_postContent\",\"postType\":\"PROJECT\",\"postMeeting\":\" \"}"
+            )
+        )
+        .andExpect(status().isBadRequest());
+  }
+
+}

--- a/src/test/java/com/project/socket/post/model/PostTest.java
+++ b/src/test/java/com/project/socket/post/model/PostTest.java
@@ -1,41 +1,55 @@
 package com.project.socket.post.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.project.socket.user.model.User;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class PostTest {
 
-    @Test
-    void post_엔티티_생성() {
-        Post post = Post.builder().id(1L).build();
-        assertThat(post).isNotNull();
-    }
+  @Test
+  void post_엔티티_생성() {
+    Post post = Post.builder().id(1L).build();
+    assertThat(post).isNotNull();
+  }
 
-    @Test
-    void 게시물_등록_테스트() {
-        User user = User.builder().userId(1L).build();
-        final String title = "안녕하세요";
-        final String postContent = "socket-backend 입니다.";
-        final PostType postType = PostType.PROJECT;
-        final PostMeeting postMeeting = PostMeeting.ONLINE;
+  @Test
+  void 게시물_등록_테스트() {
+    User user = User.builder().userId(1L).build();
+    final String title = "안녕하세요";
+    final String postContent = "socket-backend 입니다.";
+    final PostType postType = PostType.PROJECT;
+    final PostMeeting postMeeting = PostMeeting.ONLINE;
 
-        Post findPost = Post.createNewPost(user, title, postContent, postType, postMeeting);
+    Post findPost = Post.createNewPost(user, title, postContent, postType, postMeeting);
 
-        assertThat(findPost).satisfies(post -> {
-                    assertThat(post.getTitle()).isEqualTo(title);
-                    assertThat(post.getPostContent()).isEqualTo(postContent);
-                    assertThat(post.getPostType()).isEqualTo(postType);
-                    assertThat(post.getPostMeeting()).isEqualTo(postMeeting);
-                }
-        );
+    assertThat(findPost).satisfies(post -> {
+          assertThat(post.getTitle()).isEqualTo(title);
+          assertThat(post.getPostContent()).isEqualTo(postContent);
+          assertThat(post.getPostType()).isEqualTo(postType);
+          assertThat(post.getPostMeeting()).isEqualTo(postMeeting);
+        }
+    );
+  }
 
+  @Test
+  void 유효한_연관관계이면_true를_반환한다() {
+    User user = User.builder().userId(1L).build();
+    Post post = Post.builder().user(user).build();
 
-    }
+    assertThat(post.validatePostRelation(1L)).isTrue();
+  }
+
+  @Test
+  void 유효한_연관관계가_아니면_false를_반환한다() {
+    User user = User.builder().userId(1L).build();
+    Post post = Post.builder().user(user).build();
+
+    assertThat(post.validatePostRelation(2L)).isFalse();
+  }
 
 
 }

--- a/src/test/java/com/project/socket/post/service/PostModifyServiceTest.java
+++ b/src/test/java/com/project/socket/post/service/PostModifyServiceTest.java
@@ -1,0 +1,80 @@
+package com.project.socket.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostStatus;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostModifyCommand;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostModifyServiceTest {
+
+  @InjectMocks
+  PostModifyService postModifyService;
+
+  @Mock
+  PostJpaRepository postJpaRepository;
+
+  PostModifyCommand command = new PostModifyCommand(1L, 1L, "modifyTitle", "modifyContent",
+      PostType.PROJECT, PostMeeting.ONLINE);
+
+  @Test
+  void id에_해당하는_post가_없으면_PostNotFoundException_예외가_발생한다() {
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> postModifyService.modifyPostNew(command))
+        .isInstanceOf(PostNotFoundException.class);
+  }
+
+  @Test
+  void 수정할_post의_정보와_요청의_연관관계_검증이_실패하면_InvalidPostRelationException_예외가_발생한다() {
+    Post givenPost = Post.builder().id(1L).title("title").postContent("content")
+        .postMeeting(PostMeeting.ONLINE).postMeeting(PostMeeting.ONLINE)
+        .user(User.builder().userId(2L).build()).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(givenPost));
+
+    assertThatThrownBy(() -> postModifyService.modifyPostNew(command))
+        .isInstanceOf(InvalidPostRelationException.class);
+  }
+
+  @Test
+  void 요청이_유효하면_성공적으로_변경정보를_반영한다() {
+    Post givenPost = Post.builder().id(1L).title("prevTitle").postContent("prevContent")
+        .postType(PostType.STUDY).postMeeting(PostMeeting.OFFLINE)
+        .postStatus(PostStatus.CREATED)
+        .user(User.builder().userId(1L).build()).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(givenPost));
+
+    Post modifiedPost = postModifyService.modifyPostNew(command);
+
+    assertAll(
+        () -> assertThat(modifiedPost.getTitle()).isEqualTo(command.title()),
+        () -> assertThat(modifiedPost.getPostContent()).isEqualTo(command.postContent()),
+        () -> assertThat(modifiedPost.getPostType()).isEqualTo(command.postType()),
+        () -> assertThat(modifiedPost.getPostMeeting()).isEqualTo(command.postMeeting()),
+        () -> assertThat(modifiedPost.getPostStatus()).isEqualTo(PostStatus.MODIFIED)
+    );
+  }
+
+}


### PR DESCRIPTION
## PR 요약
게시물 수정 API를 구현했습니다.
1. 요청에 해당하는 Post가 존재하지 않으면 PostNotFoundException 예외가 발생하고 404 응답을 합니다.
2. Post와 연관관계가 있는 user 요청의 userId와 맞지 않으면 InvalidPostRelationException 예외가 발생하고 400 응답을 합니다.
3. 요청이 성공적으로 수행되면 200 응답을 합니다.
4. StringInputCheck 커스텀 어노테이션은 수정값을 입력하지 않을 때, String 타입의 title, postContent에 null값이 들어가는 것을 허용하기 위해 만들었습니다.

#### Linked Issue
close `#Issue number`