### PR TITLE
[FEAT] REDIS 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -208,6 +208,8 @@ jib {
                 "KAKAO_CLIENT_SECRET"   : System.getenv("KAKAO_CLIENT_SECRET"),
                 "GOOGLE_CLIENT_ID"      : System.getenv("GOOGLE_CLIENT_ID"),
                 "GOOGLE_CLIENT_SECRET"  : System.getenv("GOOGLE_CLIENT_SECRET"),
+                "REDIS_HOST"  : System.getenv("REDIS_HOST"),
+                "REDIS_PORT"  : System.getenv("REDIS_PORT"),
         ]
     }
 }

--- a/src/main/java/com/project/socket/config/RedisConfig.java
+++ b/src/main/java/com/project/socket/config/RedisConfig.java
@@ -21,8 +21,8 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisTemplate<?,?> redisTemplate(){
-    RedisTemplate<?,?> redisTemplate = new RedisTemplate<>();
+  public RedisTemplate<String, Object> redisTemplate(){
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     redisTemplate.setDefaultSerializer(new StringRedisSerializer());
     return redisTemplate;

--- a/src/main/java/com/project/socket/config/RedisConfig.java
+++ b/src/main/java/com/project/socket/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.project.socket.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+  private final RedisProperties redisProperties;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory(){
+    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+  }
+
+  @Bean
+  public RedisTemplate<?,?> redisTemplate(){
+    RedisTemplate<?,?> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/src/main/resources/application-local-cors.yml
+++ b/src/main/resources/application-local-cors.yml
@@ -1,2 +1,2 @@
 cors:
-  allow-origins: http://localhost:3000
+  allow-origins: 'http://localhost:3000, file://'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,6 +15,10 @@ spring:
         format_sql: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 logging:
   level:

--- a/src/test/java/com/project/socket/common/RedisContainerConnectTest.java
+++ b/src/test/java/com/project/socket/common/RedisContainerConnectTest.java
@@ -1,0 +1,30 @@
+package com.project.socket.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.config.ContainerBaseTest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class RedisContainerConnectTest extends ContainerBaseTest {
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @Test
+  void 레디스_컨테이너_연결_테스트() {
+    String ping = redisTemplate.getConnectionFactory().getConnection().ping();
+    final String PONG = "PONG";
+
+    assertThat(ping).isEqualTo(PONG);
+  }
+
+}

--- a/src/test/java/com/project/socket/common/RedisContainerConnectTest.java
+++ b/src/test/java/com/project/socket/common/RedisContainerConnectTest.java
@@ -14,10 +14,10 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles("test")
 @DisplayNameGeneration(ReplaceUnderscores.class)
-public class RedisContainerConnectTest extends ContainerBaseTest {
+class RedisContainerConnectTest extends ContainerBaseTest {
 
   @Autowired
-  RedisTemplate<String, String> redisTemplate;
+  RedisTemplate<String, Object> redisTemplate;
 
   @Test
   void 레디스_컨테이너_연결_테스트() {

--- a/src/test/java/com/project/socket/config/ContainerBaseTest.java
+++ b/src/test/java/com/project/socket/config/ContainerBaseTest.java
@@ -1,0 +1,18 @@
+package com.project.socket.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public abstract class ContainerBaseTest {
+  static GenericContainer<?> redis = new GenericContainer<>(
+      DockerImageName.parse("redis:7.0.8-alpine")).withExposedPorts(6379);
+
+  @DynamicPropertySource
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    redis.start();
+    registry.add("spring.data.redis.host", redis::getHost);
+    registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+  }
+}


### PR DESCRIPTION
## PR 요약
외부 메세지브로커로의 역할을 하고, 채팅 유저의 접속자 관리를 위해 REDIS를 적용했습니다.

테스트 환경에서 레디스를 이용한 테스트가 필요할 경우를 대비해 TestContainers를 이용해 Redis 컨테이너를 생성하고 이를 동적으로 spring properties 에 주입하기 위한 ContainerBaseTest 추상 클래스를 추가했습니다. 테스트가 필요한 부분에 해당 클래스를 상속해 테스트를 실행시키면 작동합니다!  static으로 redis 컨테이너를 생성하기 때문에 여러 클래스에서 상속을 해도 컨테이너는 1개만 생성하게 됩니다!! 

## 변경 사항
민오님의 로컬환경에서 REDIS 설치가 필요합니다. 레디스가 없으면 애플리케이션 실행이 실패하실거에요!

#### Linked Issue
close #60 