### PR TITLE
게시물 삭제 기능 구현

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -13,5 +13,9 @@ operation::modifyPost[snippets='http-request,path-parameters,request-headers,req
 
 operation::getSinglePost[snippets='http-request,path-parameters,http-response,response-body,response-fields']
 
+[[delete-post]]
+=== 포스트 삭제
+
+operation::deletePost[snippets='http-request,path-parameters,request-headers,http-response']
 
 

--- a/src/main/java/com/project/socket/post/controller/PostDeleteController.java
+++ b/src/main/java/com/project/socket/post/controller/PostDeleteController.java
@@ -1,0 +1,33 @@
+package com.project.socket.post.controller;
+
+import com.project.socket.post.service.usecase.PostDeleteCommand;
+import com.project.socket.post.service.usecase.PostDeleteUseCase;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class PostDeleteController {
+
+  private final PostDeleteUseCase postDeleteUseCase;
+
+  @DeleteMapping("posts/{postId}")
+  public ResponseEntity<Object> deletePost(
+      @PathVariable @Min(1) Long postId,
+      @AuthenticationPrincipal UserDetails userDetails
+  ) {
+    Long userId = Long.valueOf(userDetails.getUsername());
+
+    postDeleteUseCase.deletePostOne(new PostDeleteCommand(userId, postId));
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/project/socket/post/model/Post.java
+++ b/src/main/java/com/project/socket/post/model/Post.java
@@ -100,5 +100,7 @@ public class Post extends BaseTime {
 
   }
 
-
+  public void changeStatusToDeleted() {
+    this.postStatus = PostStatus.DELETED;
+  }
 }

--- a/src/main/java/com/project/socket/post/service/PostDeleteService.java
+++ b/src/main/java/com/project/socket/post/service/PostDeleteService.java
@@ -1,0 +1,37 @@
+package com.project.socket.post.service;
+
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostDeleteCommand;
+import com.project.socket.post.service.usecase.PostDeleteUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostDeleteService implements PostDeleteUseCase {
+
+  private final PostJpaRepository postJpaRepository;
+
+  @Transactional
+  @Override
+  public void deletePostOne(PostDeleteCommand postDeleteCommand) {
+    Post postToDelete = findPost(postDeleteCommand.postId());
+
+    if (!postToDelete.isWriter(
+        postDeleteCommand.userId())) {
+      throw new InvalidPostRelationException();
+    }
+
+    postToDelete.changeStatusToDeleted();
+  }
+
+  private Post findPost(Long postId) {
+    return postJpaRepository.findById(postId)
+        .orElseThrow(() -> new PostNotFoundException(postId));
+  }
+}

--- a/src/main/java/com/project/socket/post/service/usecase/PostDeleteCommand.java
+++ b/src/main/java/com/project/socket/post/service/usecase/PostDeleteCommand.java
@@ -1,0 +1,8 @@
+package com.project.socket.post.service.usecase;
+
+public record PostDeleteCommand(
+    Long userId,
+    Long postId
+) {
+
+}

--- a/src/main/java/com/project/socket/post/service/usecase/PostDeleteUseCase.java
+++ b/src/main/java/com/project/socket/post/service/usecase/PostDeleteUseCase.java
@@ -1,0 +1,6 @@
+package com.project.socket.post.service.usecase;
+
+public interface PostDeleteUseCase {
+
+  void deletePostOne(PostDeleteCommand postDeleteCommand);
+}

--- a/src/test/java/com/project/socket/post/controller/PostDeleteControllerTest.java
+++ b/src/test/java/com/project/socket/post/controller/PostDeleteControllerTest.java
@@ -1,0 +1,89 @@
+package com.project.socket.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.service.usecase.PostDeleteUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(PostDeleteController.class)
+public class PostDeleteControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  PostDeleteUseCase postDeleteUseCase;
+
+  final Long POST_ID = 1L;
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void 요청이_유효하면_204_응답을_한다() throws Exception {
+    doNothing().when(postDeleteUseCase).deletePostOne(any());
+
+    mockMvc.perform(delete("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken"))
+        .andExpect(status().is2xxSuccessful())
+        .andDo(
+            document("deletePost",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("postId").description("삭제할 포스트 ID")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("Bearer access-token")
+                ))
+        );
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void postId가_1보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(delete("/posts/{postId}", -1L))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void InvalidPostRelationException_예외가_발생하면_400_응답을_한다() throws Exception {
+    doThrow(new InvalidPostRelationException()).when(postDeleteUseCase).deletePostOne(any());
+
+    mockMvc.perform(delete("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "1", authorities = "ROLE_USER")
+  void PostNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception {
+    doThrow(new PostNotFoundException(POST_ID)).when(postDeleteUseCase).deletePostOne(any());
+
+    mockMvc.perform(delete("/posts/{postId}", POST_ID)
+            .header("Authorization", "Bearer accessToken"))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/com/project/socket/post/model/PostTest.java
+++ b/src/test/java/com/project/socket/post/model/PostTest.java
@@ -127,5 +127,13 @@ class PostTest {
     });
   }
 
+  @Test
+  void post의_postStatus를_DELETED로_변경한다() {
+    Post post = Post.builder().id(1L).postStatus(PostStatus.CREATED).build();
+
+    post.changeStatusToDeleted();
+
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.DELETED);
+  }
 
 }

--- a/src/test/java/com/project/socket/post/service/PostDeleteServiceTest.java
+++ b/src/test/java/com/project/socket/post/service/PostDeleteServiceTest.java
@@ -1,0 +1,66 @@
+package com.project.socket.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.post.exception.InvalidPostRelationException;
+import com.project.socket.post.exception.PostNotFoundException;
+import com.project.socket.post.model.Post;
+import com.project.socket.post.model.PostStatus;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostDeleteCommand;
+import com.project.socket.user.model.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PostDeleteServiceTest {
+
+  @InjectMocks
+  PostDeleteService postDeleteService;
+
+  @Mock
+  PostJpaRepository postJpaRepository;
+
+  PostDeleteCommand command = new PostDeleteCommand(1L, 1L);
+
+  @Test
+  void id에_해당하는_post가_없으면_PostNotFoundException_예외가_발생한다() {
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> postDeleteService.deletePostOne(command))
+        .isInstanceOf(PostNotFoundException.class);
+  }
+
+  @Test
+  void 요청한_유저의_정보와_post_작성_유저가_일치하지_않으면_InvalidPostRelationException_예외가_발생한다() {
+    Post post = Post.builder().id(1L).title("title").postContent("content")
+        .user(User.builder().userId(2L).build()).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(post));
+
+    assertThatThrownBy(() -> postDeleteService.deletePostOne(command))
+        .isInstanceOf(InvalidPostRelationException.class);
+  }
+
+  @Test
+  void 요청이_유효하면_성공적으로_postStatus를_DELETED로_변경한다() {
+    Post post = Post.builder().id(1L).title("title").postStatus(PostStatus.CREATED)
+        .user(User.builder().userId(1L).build()).build();
+
+    when(postJpaRepository.findById(anyLong())).thenReturn(Optional.of(post));
+
+    postDeleteService.deletePostOne(command);
+
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.DELETED);
+  }
+}


### PR DESCRIPTION
## PR 요약
게시물 삭제 기능 구현했습니다.
post가 존재하는지, 연관관계 예외체크를 통해 통과 되면, comment 삭제와 같이 레코드 삭제가 아닌 Post Status를 DELETED로 변경하게 했습니다.
아예 삭제하는것이 나을것 같으시면 말씀해 주세요!

#### Linked Issue
close `#Issue number`