### PR TITLE
[FEAT] 채팅 접속자 관리 구현

### DIFF
--- a/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
+++ b/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
@@ -1,0 +1,31 @@
+package com.project.socket.chatuser.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatUserRepository {
+
+  private final static String CHAT_PARTICIPANT = "chat_participant:";
+  private final static String DESTINATION = "destination";
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public void save(String sessionId, String username) {
+    redisTemplate.opsForValue().set(sessionId, username);
+  }
+
+  public void remove(String sessionId) {
+    redisTemplate.delete(sessionId);
+  }
+
+  public void subscribe(String username, String destination) {
+    redisTemplate.opsForHash()
+                 .put(CHAT_PARTICIPANT + username, DESTINATION, destination);
+  }
+
+  public void unsubscribe(String username) {
+    redisTemplate.opsForHash().delete(CHAT_PARTICIPANT + username, DESTINATION);
+  }
+}

--- a/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
+++ b/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ChatUserRepository {
 
-  private final static String CHAT_PARTICIPANT = "chat_participant:";
-  private final static String DESTINATION = "destination";
+  private static final String CHAT_PARTICIPANT = "chat_participant:";
+  private static final String DESTINATION = "destination";
   private final RedisTemplate<String, Object> redisTemplate;
 
   public void save(String sessionId, String username) {

--- a/src/main/java/com/project/socket/config/WebSocketConfig.java
+++ b/src/main/java/com/project/socket/config/WebSocketConfig.java
@@ -1,18 +1,29 @@
 package com.project.socket.config;
 
+import com.project.socket.config.handler.StompErrorHandler;
+import com.project.socket.config.handler.StompInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StompInterceptor stompInterceptor;
+  private final StompErrorHandler stompErrorHandler;
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
-    registry.enableSimpleBroker("/sub");
+    registry.enableSimpleBroker("/sub")
+            .setTaskScheduler(taskScheduler());
     registry.setApplicationDestinationPrefixes("/pub");
   }
 
@@ -20,5 +31,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws/chat")
             .setAllowedOriginPatterns("*");
+    registry.setErrorHandler(stompErrorHandler);
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompInterceptor);
+  }
+
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.initialize();
+    return taskScheduler;
   }
 }

--- a/src/main/java/com/project/socket/config/handler/StompErrorHandler.java
+++ b/src/main/java/com/project/socket/config/handler/StompErrorHandler.java
@@ -1,0 +1,27 @@
+package com.project.socket.config.handler;
+
+import static com.project.socket.common.error.ErrorCode.INVALID_JWT;
+
+import com.project.socket.security.exception.InvalidJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Component
+@Slf4j
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+
+  @Override
+  public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage,
+      Throwable ex) {
+    // 토큰 문제로 예외 발생시 예외를 재정의해서 위임
+    if (ex.getCause() instanceof InvalidJwtException) {
+      log.info(ex.getMessage());
+      ex = new MessageDeliveryException(INVALID_JWT.getMessage());
+    }
+
+    return super.handleClientMessageProcessingError(clientMessage, ex);
+  }
+}

--- a/src/main/java/com/project/socket/config/handler/StompEventListener.java
+++ b/src/main/java/com/project/socket/config/handler/StompEventListener.java
@@ -1,0 +1,61 @@
+package com.project.socket.config.handler;
+
+import com.project.socket.chatuser.repository.ChatUserRepository;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompEventListener {
+
+  private final ChatUserRepository chatUserRepository;
+
+  @EventListener
+  public void connectedHandler(SessionConnectedEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    chatUserRepository.save(accessor.getSessionId(), event.getUser().getName());
+
+    log.info("session ID :{}, username :{} CONNECT", accessor.getSessionId(),
+        event.getUser().getName());
+  }
+
+
+  @EventListener
+  public void subscribeHandler(SessionSubscribeEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    String destination = accessor.getDestination();
+    chatUserRepository.subscribe(event.getUser().getName(), destination);
+
+    log.info("session ID :{}, username :{}, destination :{} SUBSCRIBED", accessor.getSessionId(),
+        event.getUser().getName(), destination);
+  }
+
+  @EventListener
+  public void unsubscribeHandler(SessionUnsubscribeEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    String destination = accessor.getDestination();
+    chatUserRepository.unsubscribe(event.getUser().getName());
+
+    log.info("session ID :{}, username :{}, destination :{} UNSUBSCRIBED", accessor.getSessionId(),
+        event.getUser().getName(), destination);
+  }
+
+  @EventListener
+  public void disconnectHandler(SessionDisconnectEvent event) {
+    if (Objects.nonNull(event.getUser())) {
+      chatUserRepository.remove(event.getSessionId());
+      chatUserRepository.unsubscribe(event.getUser().getName());
+    }
+
+    log.info("{} DISCONNECTED", event);
+  }
+}

--- a/src/main/java/com/project/socket/config/handler/StompInterceptor.java
+++ b/src/main/java/com/project/socket/config/handler/StompInterceptor.java
@@ -1,0 +1,49 @@
+package com.project.socket.config.handler;
+
+import com.project.socket.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompInterceptor implements ChannelInterceptor {
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+    SimpMessageType messageType = accessor.getMessageType();
+
+    // Connect 연결 요청이면 InboundChannel에 메세지를 보내기전에 user 인증객체를 등록
+    if (messageType.equals(SimpMessageType.CONNECT)) {
+      String token = accessor.getFirstNativeHeader("Authorization");
+      jwtProvider.validateToken(token);
+      UserDetails userDetails = getUserDetails(jwtProvider.getSubjectFromToken(token),
+          jwtProvider.getRoleFromToken(token));
+      Authentication authentication = getAuthentication(userDetails);
+      accessor.setUser(authentication);
+    }
+
+    return message;
+  }
+
+  private Authentication getAuthentication(UserDetails userDetails) {
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  private UserDetails getUserDetails(String userId, String role) {
+    return User.builder().username(userId).password("").authorities(role).build();
+  }
+}

--- a/src/test/java/com/project/socket/chatmessage/controller/SendChatMessageControllerTest.java
+++ b/src/test/java/com/project/socket/chatmessage/controller/SendChatMessageControllerTest.java
@@ -9,15 +9,21 @@ import com.project.socket.chatmessage.controller.dto.request.SendChatMessageRequ
 import com.project.socket.chatmessage.model.ChatMessage;
 import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
 import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.config.ContainerBaseTest;
+import com.project.socket.security.JwtProvider;
+import com.project.socket.user.model.Role;
 import com.project.socket.user.model.User;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -30,11 +36,12 @@ import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class SendChatMessageControllerTest {
+class SendChatMessageControllerTest extends ContainerBaseTest {
 
   @LocalServerPort
   private int port;
@@ -42,8 +49,11 @@ class SendChatMessageControllerTest {
   private WebSocketStompClient stompClient;
   @MockBean
   private SendChatMessageUseCase sendChatMessageUseCase;
-  private static final String SEND_MESSAGE_ENDPOINT = "/pub/rooms/";
-  private static final String SUBSCRIBE_CHAT_ROOM_ENDPOINT = "/sub/rooms/";
+  final String SEND_MESSAGE_ENDPOINT = "/pub/rooms/";
+  final String SUBSCRIBE_CHAT_ROOM_ENDPOINT = "/sub/rooms/";
+
+  @Autowired
+  private JwtProvider jwtProvider;
 
   @BeforeEach
   void setup() {
@@ -55,8 +65,12 @@ class SendChatMessageControllerTest {
   @Test
   void 메세지를_발행하면_endpoint를_구독하는_클라이언트에게_전송된다() throws Exception {
     final Long ROOM_ID = 1L;
-    StompSession stompSession = stompClient.connectAsync(URL, new StompSessionHandlerAdapter() {
-    }).get(1, SECONDS);
+    StompHeaders connectionHeaders = createConnectionHeaders();
+    URI uri = UriComponentsBuilder.fromUriString(URL).buildAndExpand(List.of()).encode().toUri();
+
+    StompSession stompSession = stompClient.connectAsync(uri, null, connectionHeaders,
+        new StompSessionHandlerAdapter() {
+        }).get(5, SECONDS);
 
     MessageFrameHandler<byte[]> handler = new MessageFrameHandler<>(
         byte[].class);
@@ -70,6 +84,7 @@ class SendChatMessageControllerTest {
     byte[] chatMessageByte = handler.completableFuture.get(10, SECONDS);
     String json = new String(chatMessageByte);
 
+    stompSession.disconnect();
     assertThat(json).contains("hi");
   }
 
@@ -92,6 +107,14 @@ class SendChatMessageControllerTest {
     public void handleFrame(StompHeaders headers, Object payload) {
       completableFuture.complete((T) payload);
     }
+  }
+
+  StompHeaders createConnectionHeaders() {
+    User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
+    String accessToken = jwtProvider.createAccessToken(user);
+    StompHeaders stompHeaders = new StompHeaders();
+    stompHeaders.set("Authorization", accessToken);
+    return stompHeaders;
   }
 
   ChatMessage createChatMessage() throws Exception {

--- a/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.project.socket.chatuser.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.config.ContainerBaseTest;
+import com.project.socket.config.RedisConfig;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataRedisTest
+@Import({ChatUserRepository.class, RedisConfig.class})
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ActiveProfiles("test")
+class ChatUserRepositoryTest extends ContainerBaseTest {
+
+  @Autowired
+  ChatUserRepository chatUserRepository;
+
+  @Autowired
+  RedisTemplate<String, Object> redisTemplate;
+
+  final String CHAT_PARTICIPANT = "chat_participant:";
+
+  @Test
+  void 유저정보를_저장한다() {
+    final String sessionId = "1";
+    final String username = "1";
+
+    chatUserRepository.save(sessionId, username);
+
+    String savedUsername = (String) redisTemplate.opsForValue().get(sessionId);
+
+    assertThat(savedUsername).isEqualTo(username);
+  }
+
+  @Test
+  void 구독정보를_저장한다() {
+    final String username = "1";
+    final String destination = "/sub/rooms/1";
+
+    chatUserRepository.subscribe(username, destination);
+
+    String savedDestination = (String) redisTemplate.opsForHash()
+                                                    .get(CHAT_PARTICIPANT + username,
+                                                        "destination");
+
+    assertThat(savedDestination).isEqualTo(destination);
+  }
+
+  @Test
+  void 구독정보를_삭제한다() {
+    final String username = "1";
+    final String destination = "/sub/rooms/1";
+
+    chatUserRepository.subscribe(username, destination);
+    chatUserRepository.unsubscribe(username);
+
+    Boolean isExist = redisTemplate.opsForHash()
+                                   .hasKey(CHAT_PARTICIPANT + username, "destination");
+
+    assertThat(isExist).isFalse();
+  }
+
+  @Test
+  void 유저정보를_삭제한다() {
+    final String sessionId = "1";
+    final String username = "1";
+
+    chatUserRepository.save(sessionId, username);
+    chatUserRepository.remove(sessionId);
+
+    Object removedUsername = redisTemplate.opsForValue().get(sessionId);
+
+    assertThat(removedUsername).isNull();
+  }
+
+}

--- a/src/test/java/com/project/socket/config/handler/StompErrorHandlerTest.java
+++ b/src/test/java/com/project/socket/config/handler/StompErrorHandlerTest.java
@@ -1,0 +1,43 @@
+package com.project.socket.config.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.security.exception.InvalidJwtException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StompErrorHandlerTest {
+
+  StompErrorHandler stompErrorHandler = new StompErrorHandler();
+
+  @Test
+  void 토큰_인증_예외가_발생하면_예외를_재정의하고_위임시킨다() {
+    MessageDeliveryException exception = new MessageDeliveryException(null,
+        new InvalidJwtException("invalid token", ErrorCode.INVALID_JWT));
+
+    Message<byte[]> message = stompErrorHandler.handleClientMessageProcessingError(null,
+        exception);
+
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    assertThat(accessor.getMessage()).isEqualTo(ErrorCode.INVALID_JWT.getMessage());
+  }
+
+  @Test
+  void 에러_메세지_처리를_위임시킨다() {
+    MessageDeliveryException exception = new MessageDeliveryException("exception");
+
+    Message<byte[]> message = stompErrorHandler.handleClientMessageProcessingError(null,
+        exception);
+
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    assertThat(accessor.getMessage()).isEqualTo(exception.getMessage());
+  }
+}

--- a/src/test/java/com/project/socket/config/handler/StompEventListenerTest.java
+++ b/src/test/java/com/project/socket/config/handler/StompEventListenerTest.java
@@ -1,0 +1,142 @@
+package com.project.socket.config.handler;
+
+import static com.project.socket.user.model.Role.ROLE_USER;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.project.socket.chatuser.repository.ChatUserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class StompEventListenerTest {
+
+  @InjectMocks
+  StompEventListener stompEventListener;
+
+  @Mock
+  ChatUserRepository chatUserRepository;
+
+  final String SESSION_ID = "123-123";
+  final String USERNAME = "1";
+
+  final String DESTINATION = "/sub/rooms/1";
+
+
+  @Test
+  void SessionConnectedEvent는_유저의_세션정보를_저장한다() {
+    Authentication authentication = createAuthentication();
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECTED);
+    accessor.setSessionId(SESSION_ID);
+    Message<byte[]> message = MessageBuilder.createMessage(new byte[0],
+        accessor.getMessageHeaders());
+    SessionConnectedEvent event = new SessionConnectedEvent(this, message, authentication);
+
+    doNothing().when(chatUserRepository).save(anyString(), anyString());
+
+    stompEventListener.connectedHandler(event);
+
+    verify(chatUserRepository, times(1)).save(anyString(), anyString());
+  }
+
+
+  @Test
+  void SessionSubscribeEvent는_구독정보를_저장한다() {
+    Authentication authentication = createAuthentication();
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionId(SESSION_ID);
+    accessor.setDestination(DESTINATION);
+    Message<byte[]> message = MessageBuilder.createMessage(new byte[0],
+        accessor.getMessageHeaders());
+
+    doNothing().when(chatUserRepository).subscribe(anyString(), anyString());
+
+    SessionSubscribeEvent event = new SessionSubscribeEvent(this, message, authentication);
+
+    stompEventListener.subscribeHandler(event);
+
+    verify(chatUserRepository, times(1)).subscribe(anyString(), anyString());
+  }
+
+  @Test
+  void SessionUnsubscribeEvent는_구독정보를_삭제한다() {
+    Authentication authentication = createAuthentication();
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
+    accessor.setSessionId(SESSION_ID);
+    accessor.setDestination(DESTINATION);
+    Message<byte[]> message = MessageBuilder.createMessage(new byte[0],
+        accessor.getMessageHeaders());
+
+    doNothing().when(chatUserRepository).unsubscribe(anyString());
+
+    SessionUnsubscribeEvent event = new SessionUnsubscribeEvent(this, message, authentication);
+
+    stompEventListener.unsubscribeHandler(event);
+
+    verify(chatUserRepository, times(1)).unsubscribe(anyString());
+  }
+
+  @Test
+  void SessionDisconnectEvent는_유저_세션정보와_구독정보를_삭제한다() {
+    Authentication authentication = createAuthentication();
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+    Message<byte[]> message = MessageBuilder.createMessage(new byte[0],
+        accessor.getMessageHeaders());
+
+    doNothing().when(chatUserRepository).remove(anyString());
+    doNothing().when(chatUserRepository).unsubscribe(anyString());
+
+    SessionDisconnectEvent event = new SessionDisconnectEvent(this, message, SESSION_ID,
+        CloseStatus.NORMAL, authentication);
+
+    stompEventListener.disconnectHandler(event);
+
+    verify(chatUserRepository, times(1)).remove(anyString());
+    verify(chatUserRepository, times(1)).unsubscribe(anyString());
+  }
+
+  @Test
+  void SessionDisconnectEvent는_인증정보가_없으면_삭제작업을_수행하지_않는다() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+    Message<byte[]> message = MessageBuilder.createMessage(new byte[0],
+        accessor.getMessageHeaders());
+
+    SessionDisconnectEvent event = new SessionDisconnectEvent(this, message, SESSION_ID,
+        CloseStatus.NORMAL, null);
+
+    stompEventListener.disconnectHandler(event);
+
+    verify(chatUserRepository, never()).remove(anyString());
+    verify(chatUserRepository, never()).unsubscribe(anyString());
+  }
+
+
+  Authentication createAuthentication() {
+    UserDetails user = User.builder().username(USERNAME).password("").authorities(ROLE_USER.name())
+                           .build();
+    return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
+  }
+
+}


### PR DESCRIPTION
## PR 요약
채팅 메세지 기능 중 읽음 안읽음 기능을 구현하기 위해서는 채팅 접속자 추적해야지 가능할 것 같아서 접속자 관리 기능을 구현했습니다.
채팅 접속자는 빠른 조회와 같은 성능이 중요하다고 생각해서 `Redis`를 이용했습니다.

1. Interceptor를 추가해 클라이언트에서 온 연결 메시지가  `InboundChannel` 에 추가되기 전에 JWT 토큰 인증을 수행하고 인증객체를 메세지 헤더에 추가해주는 인증과정을 구현했습니다.
2. 연결, 구독요청, 구독취소, 연결 끊기등 작업에 따라 `StompSubProtocolHandler`에서 이벤트를 발행시킵니다. 그래서 해당 이벤트를 소비하기 위한 리스너를 구현하고 이벤트에 따라 Redis에 세션 정보, 구독정보를 저장, 삭제하는 로직을 구현했습니다.
3. Socket 통신 중 발생하는 에러처리는 기본적으로 구현되어있지만 토큰 인증 문제시 응답을 커스텀하기 위해 `StompErrorHandler`를 추가했습니다. 토큰 인증 문제시 기존 예외를 재정의하고 응답처리를 부모클래스에게 위임합니다.

이해안되시거나 이상한 부분있으면 말씀해주세요!!

#### Linked Issue
close #62 