### PR TITLE
[FEAT] 채팅 접속상태에 따라 읽음 안읽음 메세지를 보내도록 변경

### DIFF
--- a/src/main/java/com/project/socket/chatmessage/model/ChatMessage.java
+++ b/src/main/java/com/project/socket/chatmessage/model/ChatMessage.java
@@ -49,4 +49,8 @@ public class ChatMessage extends BaseCreatedTime {
     this.content = content;
     this.readCount = readCount;
   }
+
+  public void toRead(){
+    this.readCount = 0;
+  }
 }

--- a/src/main/java/com/project/socket/chatmessage/service/SendChatMessageService.java
+++ b/src/main/java/com/project/socket/chatmessage/service/SendChatMessageService.java
@@ -7,9 +7,11 @@ import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
 import com.project.socket.chatroom.exception.ChatRoomNotFoundException;
 import com.project.socket.chatroom.model.ChatRoom;
 import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.chatuser.repository.ChatUserRepository;
 import com.project.socket.user.exception.UserNotFoundException;
 import com.project.socket.user.model.User;
 import com.project.socket.user.repository.UserJpaRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +22,7 @@ public class SendChatMessageService implements SendChatMessageUseCase {
   private final ChatMessageRepository chatMessageRepository;
   private final ChatRoomRepository chatRoomRepository;
   private final UserJpaRepository userJpaRepository;
+  private final ChatUserRepository chatUserRepository;
 
   @Override
   public ChatMessage sendChatMessage(SendChatMessageCommand command) {
@@ -30,7 +33,21 @@ public class SendChatMessageService implements SendChatMessageUseCase {
                                          .content(command.content()).sender(sender)
                                          .build();
 
+    if (isReceiverInTheRoom(command.receiverId(), command.chatRoomId())) {
+      chatMessage.toRead();
+    }
+
     return chatMessageRepository.save(chatMessage);
+  }
+
+  private boolean isReceiverInTheRoom(Long receiverId, Long chatRoomId) {
+    String destination = chatUserRepository.findDestinationById(receiverId);
+
+    if (Objects.nonNull(destination)) {
+      return destination.equals("/sub/rooms/" + chatRoomId);
+    } else {
+      return false;
+    }
   }
 
   private ChatRoom findChatRoom(Long chatRoomId) {

--- a/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
+++ b/src/main/java/com/project/socket/chatuser/repository/ChatUserRepository.java
@@ -25,6 +25,10 @@ public class ChatUserRepository {
                  .put(CHAT_PARTICIPANT + username, DESTINATION, destination);
   }
 
+  public String findDestinationById(Long userId) {
+    return (String) redisTemplate.opsForHash().get(CHAT_PARTICIPANT + userId, DESTINATION);
+  }
+
   public void unsubscribe(String username) {
     redisTemplate.opsForHash().delete(CHAT_PARTICIPANT + username, DESTINATION);
   }

--- a/src/test/java/com/project/socket/chatmessage/service/SendChatMessageServiceTest.java
+++ b/src/test/java/com/project/socket/chatmessage/service/SendChatMessageServiceTest.java
@@ -2,8 +2,10 @@ package com.project.socket.chatmessage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.project.socket.chatmessage.model.ChatMessage;
@@ -12,6 +14,7 @@ import com.project.socket.chatmessage.service.usecase.SendChatMessageCommand;
 import com.project.socket.chatroom.exception.ChatRoomNotFoundException;
 import com.project.socket.chatroom.model.ChatRoom;
 import com.project.socket.chatroom.repository.ChatRoomRepository;
+import com.project.socket.chatuser.repository.ChatUserRepository;
 import com.project.socket.user.exception.UserNotFoundException;
 import com.project.socket.user.model.User;
 import com.project.socket.user.repository.UserJpaRepository;
@@ -20,6 +23,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,8 +42,14 @@ class SendChatMessageServiceTest {
   @Mock
   ChatMessageRepository chatMessageRepository;
 
+  @Mock
+  ChatUserRepository chatUserRepository;
+
   @InjectMocks
   SendChatMessageService sendChatMessageService;
+
+  @Captor
+  ArgumentCaptor<ChatMessage> chatMessageCaptor;
 
   SendChatMessageCommand command = new SendChatMessageCommand(1L, 1L, 2L, "HI");
 
@@ -59,18 +70,79 @@ class SendChatMessageServiceTest {
   }
 
   @Test
-  void 성공적으로_ChatMessage를_저장하고_반환한다() {
+  void 상대방이_접속중이면_ChatMessage를_읽음처리_저장하고_반환한다() {
     ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
     User sender = User.builder().userId(1L).build();
     ChatMessage chatMessage = ChatMessage.builder().chatMessageId(1L).chatRoom(chatRoom)
                                          .sender(sender)
                                          .build();
+
+    String receiverDestination = "/sub/rooms/1";
     when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
     when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(sender));
+    when(chatUserRepository.findDestinationById(anyLong())).thenReturn(receiverDestination);
     when(chatMessageRepository.save(any())).thenReturn(chatMessage);
 
     ChatMessage savedChatMessage = sendChatMessageService.sendChatMessage(command);
 
-    assertThat(savedChatMessage.getChatMessageId()).isEqualTo(chatMessage.getChatMessageId());
+    verify(chatMessageRepository).save(chatMessageCaptor.capture());
+    ChatMessage captureChatMessage = chatMessageCaptor.getValue();
+
+    assertAll(
+        () -> assertThat(savedChatMessage.getChatMessageId()).isEqualTo(
+            chatMessage.getChatMessageId()),
+        () -> assertThat(captureChatMessage.getReadCount()).isZero()
+    );
+  }
+
+  @Test
+  void 상대방이_다른_채팅방에_접속중이면_ChatMessage를_안읽음처리_저장하고_반환한다() {
+    ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
+    User sender = User.builder().userId(1L).build();
+    ChatMessage chatMessage = ChatMessage.builder().chatMessageId(1L).chatRoom(chatRoom)
+                                         .sender(sender)
+                                         .build();
+
+    String receiverDestination = "/sub/rooms/2";
+    when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(sender));
+    when(chatUserRepository.findDestinationById(anyLong())).thenReturn(receiverDestination);
+    when(chatMessageRepository.save(any())).thenReturn(chatMessage);
+
+    ChatMessage savedChatMessage = sendChatMessageService.sendChatMessage(command);
+
+    verify(chatMessageRepository).save(chatMessageCaptor.capture());
+    ChatMessage captureChatMessage = chatMessageCaptor.getValue();
+
+    assertAll(
+        () -> assertThat(savedChatMessage.getChatMessageId()).isEqualTo(
+            chatMessage.getChatMessageId()),
+        () -> assertThat(captureChatMessage.getReadCount()).isEqualTo(1)
+    );
+  }
+
+  @Test
+  void 상대방이_접속중이_아니면_ChatMessage를_안읽음처리_저장하고_반환한다() {
+    ChatRoom chatRoom = ChatRoom.builder().chatRoomId(1L).build();
+    User sender = User.builder().userId(1L).build();
+    ChatMessage chatMessage = ChatMessage.builder().chatMessageId(1L).chatRoom(chatRoom)
+                                         .sender(sender)
+                                         .build();
+
+    when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(chatRoom));
+    when(userJpaRepository.findById(anyLong())).thenReturn(Optional.of(sender));
+    when(chatUserRepository.findDestinationById(anyLong())).thenReturn(null);
+    when(chatMessageRepository.save(any())).thenReturn(chatMessage);
+
+    ChatMessage savedChatMessage = sendChatMessageService.sendChatMessage(command);
+
+    verify(chatMessageRepository).save(chatMessageCaptor.capture());
+    ChatMessage captureChatMessage = chatMessageCaptor.getValue();
+
+    assertAll(
+        () -> assertThat(savedChatMessage.getChatMessageId()).isEqualTo(
+            chatMessage.getChatMessageId()),
+        () -> assertThat(captureChatMessage.getReadCount()).isEqualTo(1)
+    );
   }
 }

--- a/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
@@ -87,7 +87,7 @@ class ChatUserRepositoryTest extends ContainerBaseTest {
 
     String result = chatUserRepository.findDestinationById(1L);
 
-    assertThat(result).isEqualTo(result);
+    assertThat(result).isEqualTo(destination);
   }
 
   @Test

--- a/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatuser/repository/ChatUserRepositoryTest.java
@@ -80,4 +80,20 @@ class ChatUserRepositoryTest extends ContainerBaseTest {
     assertThat(removedUsername).isNull();
   }
 
+  @Test
+  void 유저의_구독_위치를_반환한다() {
+    String destination = "/sub/rooms/1";
+    chatUserRepository.subscribe("1", destination);
+
+    String result = chatUserRepository.findDestinationById(1L);
+
+    assertThat(result).isEqualTo(result);
+  }
+
+  @Test
+  void 유저의_구독정보가_없으면_null을_반환한다() {
+    String result = chatUserRepository.findDestinationById(1L);
+
+    assertThat(result).isNull();
+  }
 }


### PR DESCRIPTION

## PR 요약
REDIS에 저장된 채팅방 구독 정보를 사용해 상대방에게 메세지를 전송시 읽음 안읽음 분기처리를 하도록 변경했습니다.

#### Linked Issue
close #69 