### PR TITLE
Cookie secure 설정

### DIFF
--- a/src/main/java/com/project/socket/security/CookieUtils.java
+++ b/src/main/java/com/project/socket/security/CookieUtils.java
@@ -29,6 +29,7 @@ public class CookieUtils {
       int maxAge) {
     Cookie cookie = new Cookie(name, value);
     cookie.setPath("/");
+    cookie.setSecure(true);
     cookie.setHttpOnly(true);
     cookie.setMaxAge(maxAge);
     response.addCookie(cookie);


### PR DESCRIPTION
## PR 요약
SonarQube 에서 쿠키 보안 문제로 작업실패
Cookie 의 secure 옵션을 true 설정해 HTTPS 통신에서만 쿠키가 전달되도록 설정
