### PR TITLE
hashtag(skillName)을 이용한 게시물 조회

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -24,10 +24,15 @@ include::signup.adoc[]
 
 include::comment.adoc[]
 
-[[postAPI]]
+[[POST-API]]
 == Post API
 
 include::post.adoc[]
+
+[[POSTSKILL-API]]
+== PostSkill API
+
+include::postskill.adoc[]
 
 [[CHATROOM-API]]
 == Chat Room API

--- a/src/docs/asciidoc/postskill.adoc
+++ b/src/docs/asciidoc/postskill.adoc
@@ -1,0 +1,5 @@
+[[get-all-post-skill]]
+=== 포스트 태그 게시물 조회
+
+operation::getAllPostsOfSkill[snippets='http-request,query-parameters,http-response,response-body,response-fields']
+

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -26,6 +26,12 @@ public enum ErrorCode {
   COMMENT_NOT_FOUND(404, "CM1", "해당 댓글이 존재하지 않습니다"),
   INVALID_COMMENT_RELATION(400, "CM2", "잘못된 요청입니다"),
 
+  // Post Skill
+  UnsupportedSortException(400, "P4", "지원하지 않는 정렬조건 입니다"),
+
+  // skill
+  SKILL_NOT_FOUND(404, "S1", "해당 태그와 관련된 게시물이 존재하지 않습니다"),
+
   /**
    * ChatRoom 관련 에러 코드
    */

--- a/src/main/java/com/project/socket/config/SecurityConfig.java
+++ b/src/main/java/com/project/socket/config/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig {
             .requestMatchers("/docs/**", "/actuator/**", "/error/**", "/").permitAll()
             .requestMatchers("/ws/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/{postId}/comments").permitAll()
+            .requestMatchers(HttpMethod.GET, "/posts/{postId}").permitAll()
+            .requestMatchers(HttpMethod.GET, "/posts/projects").permitAll()
             .requestMatchers("/signup").authenticated()
             .requestMatchers(HttpMethod.POST, "/posts/{postId}/chat-rooms")
             .hasAuthority(Role.ROLE_USER.name())
@@ -74,9 +76,9 @@ public class SecurityConfig {
   private List<String> corsOrigins;
 
   @Bean
-  public WebSecurityCustomizer webSecurityCustomizer(){
+  public WebSecurityCustomizer webSecurityCustomizer() {
     return web -> web.ignoring()
-                     .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+        .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
   }
 
   @Bean

--- a/src/main/java/com/project/socket/post/controller/dto/response/PagePostResponseDto.java
+++ b/src/main/java/com/project/socket/post/controller/dto/response/PagePostResponseDto.java
@@ -1,0 +1,51 @@
+package com.project.socket.post.controller.dto.response;
+
+import com.project.socket.post.service.usecase.PostDto;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PagePostResponseDto(
+    List<PostResponseDto> content,
+    PageMetaData pageMetaData
+) {
+
+  public record PageMetaData(
+      long totalElements,
+      int totalPages,
+      int pageNumber,
+      int pageSize,
+      int currentPageElements,
+      boolean isFirstPage,
+      boolean isLastPage,
+      boolean hasPreviousPage,
+      boolean hasNextPage,
+      String sortCriteria,
+      String sortDirection
+  ) {
+
+  }
+
+  public static PagePostResponseDto toResponse(Page<PostDto> postDtoPage) {
+    List<PostResponseDto> content = postDtoPage.getContent().stream()
+        .map(PostResponseDto::toResponse).toList();
+
+    String property = postDtoPage.getSort().iterator().next().getProperty();
+
+    return new PagePostResponseDto(
+        content,
+        new PageMetaData(
+            postDtoPage.getTotalElements(),
+            postDtoPage.getTotalPages(),
+            postDtoPage.getNumber(),
+            postDtoPage.getSize(),
+            postDtoPage.getNumberOfElements(),
+            postDtoPage.isFirst(),
+            postDtoPage.isLast(),
+            postDtoPage.hasPrevious(),
+            postDtoPage.hasNext(),
+            postDtoPage.getSort().iterator().next().getProperty(),
+            postDtoPage.getSort().getOrderFor(property).getDirection().name()
+        )
+    );
+  }
+}

--- a/src/main/java/com/project/socket/post/controller/dto/response/PagePostResponseDto.java
+++ b/src/main/java/com/project/socket/post/controller/dto/response/PagePostResponseDto.java
@@ -1,6 +1,7 @@
 package com.project.socket.post.controller.dto.response;
 
 import com.project.socket.post.service.usecase.PostDto;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
@@ -26,6 +27,13 @@ public record PagePostResponseDto(
   }
 
   public static PagePostResponseDto toResponse(Page<PostDto> postDtoPage) {
+    if (postDtoPage.isEmpty()) {
+      return new PagePostResponseDto(
+          Collections.emptyList(),
+          new PageMetaData(0, 0, 0, 0, 0, true, true, false, false, "", "")
+      );
+    }
+
     List<PostResponseDto> content = postDtoPage.getContent().stream()
         .map(PostResponseDto::toResponse).toList();
 

--- a/src/main/java/com/project/socket/post/exception/UnsupportedSortException.java
+++ b/src/main/java/com/project/socket/post/exception/UnsupportedSortException.java
@@ -1,0 +1,11 @@
+package com.project.socket.post.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class UnsupportedSortException extends BusinessException {
+
+  public UnsupportedSortException() {
+    super(ErrorCode.UnsupportedSortException);
+  }
+}

--- a/src/main/java/com/project/socket/post/repository/PostJpaRepositoryCustom.java
+++ b/src/main/java/com/project/socket/post/repository/PostJpaRepositoryCustom.java
@@ -1,9 +1,15 @@
 package com.project.socket.post.repository;
 
 import com.project.socket.post.service.usecase.PostDto;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.HashSet;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostJpaRepositoryCustom {
 
   Optional<PostDto> findPostByPostId(Long postId);
+
+  Page<PostDto> getPostsByHashTag(HashSet<Long> idList, Pageable pageable, OrderSpecifier<?> orderSpecifier);
 }

--- a/src/main/java/com/project/socket/post/repository/PostJpaRepositoryImpl.java
+++ b/src/main/java/com/project/socket/post/repository/PostJpaRepositoryImpl.java
@@ -3,12 +3,21 @@ package com.project.socket.post.repository;
 import static com.project.socket.post.model.QPost.post;
 import static com.project.socket.user.model.QUser.user;
 
+import com.project.socket.post.model.Post;
 import com.project.socket.post.service.usecase.PostDto;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -39,4 +48,43 @@ public class PostJpaRepositoryImpl implements PostJpaRepositoryCustom {
   private BooleanExpression eqPostId(Long postId) {
     return postId != null ? post.id.eq(postId) : null;
   }
+
+  @Transactional(readOnly = true)
+  @Override
+  public Page<PostDto> getPostsByHashTag(HashSet<Long> idList, Pageable pageable, OrderSpecifier<?> orderSpecifier) {
+
+    List<PostDto> content = jpaQueryFactory
+        .select(Projections.fields(PostDto.class,
+            post.id.as("postId"),
+            post.title,
+            post.postContent,
+            post.postType,
+            post.postMeeting,
+            post.postStatus,
+            post.createdAt,
+            post.user.userId,
+            post.user.nickname.as("userNickname")))
+        .from(post)
+        .join(post.user, user)
+        .where(isEmptyPostId(idList))
+        .orderBy(orderSpecifier)
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Post> query = jpaQueryFactory
+        .select(post)
+        .from(post)
+        .join(post.user, user)
+        .where(post.id.in(idList));
+
+    int count = query.fetch().size();
+
+    return new PageImpl<>(content, pageable, count);
+  }
+
+  private BooleanExpression isEmptyPostId(HashSet<Long> idList) {
+    return !idList.isEmpty() ? post.id.in(idList) : null;
+  }
+
 }

--- a/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
+++ b/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
@@ -24,12 +24,12 @@ public class GetAllPostsOfSkillController {
 
   @GetMapping("/posts/projects")
   public ResponseEntity<Object> getAllPostsByHashTag(
-      @RequestParam(required = false) String hashtag,
-      @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
-      @RequestParam(name = "order", defaultValue = "createdAt") String order
+      @RequestParam(name = "hashtag", required = false) String hashtag,
+      @RequestParam(name = "page", required = false, defaultValue = "0") @Min(0) int page,
+      @RequestParam(name = "order", required = false, defaultValue = "createdAt") String order
   ) {
 
-    int size = 5;
+    int size = 10;
 
     Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, order);
 

--- a/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
+++ b/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
@@ -4,6 +4,7 @@ import com.project.socket.post.controller.dto.response.PagePostResponseDto;
 import com.project.socket.post.service.usecase.PostDto;
 import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,7 +25,7 @@ public class GetAllPostsOfSkillController {
 
   @GetMapping("/posts/projects")
   public ResponseEntity<Object> getAllPostsByHashTag(
-      @RequestParam(name = "hashtag", required = false) String hashtag,
+      @RequestParam(name = "hashtag", required = false) List<Long> hashtagIds,
       @RequestParam(name = "page", required = false, defaultValue = "0") @Min(0) int page,
       @RequestParam(name = "order", required = false, defaultValue = "createdAt") String order
   ) {
@@ -34,7 +35,7 @@ public class GetAllPostsOfSkillController {
     Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, order);
 
     Page<PostDto> postsUsingSkill =
-        getAllPostsOfSkillUseCase.getPostsUsingSkill(hashtag, pageable);
+        getAllPostsOfSkillUseCase.getPostsUsingSkill(hashtagIds, pageable);
 
     PagePostResponseDto responseDto = PagePostResponseDto.toResponse(postsUsingSkill);
 

--- a/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
+++ b/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
@@ -38,7 +38,7 @@ public class GetAllPostsOfSkillController {
         getAllPostsOfSkillUseCase.getPostsUsingSkill(hashtagIds, pageable);
 
     PagePostResponseDto responseDto = PagePostResponseDto.toResponse(postsUsingSkill);
-
+    
     return ResponseEntity.ok(responseDto);
   }
 }

--- a/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
+++ b/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
@@ -22,7 +22,7 @@ public class GetAllPostsOfSkillController {
 
   private final GetAllPostsOfSkillUseCase getAllPostsOfSkillUseCase;
 
-  @GetMapping("/posts")
+  @GetMapping("/posts/projects")
   public ResponseEntity<Object> getAllPostsByHashTag(
       @RequestParam(required = false) String hashtag,
       @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,

--- a/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
+++ b/src/main/java/com/project/socket/postskill/controller/GetAllPostsOfSkillController.java
@@ -1,0 +1,43 @@
+package com.project.socket.postskill.controller;
+
+import com.project.socket.post.controller.dto.response.PagePostResponseDto;
+import com.project.socket.post.service.usecase.PostDto;
+import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class GetAllPostsOfSkillController {
+
+  private final GetAllPostsOfSkillUseCase getAllPostsOfSkillUseCase;
+
+  @GetMapping("/posts")
+  public ResponseEntity<Object> getAllPostsByHashTag(
+      @RequestParam(required = false) String hashtag,
+      @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
+      @RequestParam(name = "order", defaultValue = "createdAt") String order
+  ) {
+
+    int size = 5;
+
+    Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, order);
+
+    Page<PostDto> postsUsingSkill =
+        getAllPostsOfSkillUseCase.getPostsUsingSkill(hashtag, pageable);
+
+    PagePostResponseDto responseDto = PagePostResponseDto.toResponse(postsUsingSkill);
+
+    return ResponseEntity.ok(responseDto);
+  }
+}

--- a/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepository.java
+++ b/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepository.java
@@ -1,15 +1,10 @@
 package com.project.socket.postskill.repository;
 
 import com.project.socket.postskill.model.PostSkill;
-import java.util.HashSet;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface PostSkillJpaRepository extends JpaRepository<PostSkill, Long> {
+public interface PostSkillJpaRepository extends JpaRepository<PostSkill, Long>,
+    PostSkillJpaRepositoryCustom {
 
-  @Query(value = "SELECT ps.psPost.id FROM PostSkill ps WHERE ps.psSkill.id in :skillIdList")
-  HashSet<Long> findPostIdsBySkillIds(@Param("skillIdList") List<Long> skillIdList);
 
 }

--- a/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepository.java
+++ b/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepository.java
@@ -1,9 +1,15 @@
 package com.project.socket.postskill.repository;
 
 import com.project.socket.postskill.model.PostSkill;
+import java.util.HashSet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostSkillJpaRepository extends JpaRepository<PostSkill, Long> {
 
+  @Query(value = "SELECT ps.psPost.id FROM PostSkill ps WHERE ps.psSkill.id in :skillIdList")
+  HashSet<Long> findPostIdsBySkillIds(@Param("skillIdList") List<Long> skillIdList);
 
 }

--- a/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryCustom.java
+++ b/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.project.socket.postskill.repository;
+
+import java.util.HashSet;
+import java.util.List;
+
+public interface PostSkillJpaRepositoryCustom {
+
+  HashSet<Long> findPostIdsBySkillIds(List<Long> skillIdList);
+}

--- a/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryImpl.java
+++ b/src/main/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.project.socket.postskill.repository;
+
+import static com.project.socket.postskill.model.QPostSkill.postSkill;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.HashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class PostSkillJpaRepositoryImpl implements PostSkillJpaRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Transactional(readOnly = true)
+  @Override
+  public HashSet<Long> findPostIdsBySkillIds(List<Long> skillIdList) {
+    return new HashSet<>(jpaQueryFactory
+        .select(postSkill.psPost.id)
+        .from(postSkill)
+        .where(postSkill.psSkill.id.in(skillIdList))
+        .fetch()
+    );
+  }
+}

--- a/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
+++ b/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
@@ -8,11 +8,9 @@ import com.project.socket.post.service.usecase.PostDto;
 import com.project.socket.postskill.repository.PostSkillJpaRepository;
 import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
 import com.project.socket.skill.exception.SkillNotFoundException;
-import com.project.socket.skill.repository.SkillJpaRepository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,26 +25,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetAllPostsOfSkillService implements GetAllPostsOfSkillUseCase {
 
   private final PostJpaRepository postJpaRepository;
-  private final SkillJpaRepository skillJpaRepository;
   private final PostSkillJpaRepository postSkillJpaRepository;
 
   @Override
   @Transactional(readOnly = true)
-  public Page<PostDto> getPostsUsingSkill(String skillName, Pageable pageable) {
+  public Page<PostDto> getPostsUsingSkill(List<Long> skillIdList, Pageable pageable) {
     HashSet<Long> allPostIdBySkill = new HashSet<>();
 
-    if (skillName != null && !skillName.isEmpty()) {
-      List<String> hashTags = splitHashTagsUrl(skillName);
+    if (skillIdList != null && !skillIdList.isEmpty()) {
+      //skillId와 맵핑된 postId List로 반환. 각각 다른 skillId 2개가 한개의 postId를 가리킬 경우.중복 제거
+      allPostIdBySkill = postSkillJpaRepository.findPostIdsBySkillIds(skillIdList);
 
-      // strings에 있는 skillName의 Id값 list에 저장
-      List<Long> skillIdsBySkillName = skillJpaRepository.findAllIdBySkillNames(hashTags);
-      if (skillIdsBySkillName.isEmpty()) {
+      if (allPostIdBySkill.isEmpty()) {
+        // 입력받은 해시태그ID와 맵핑된 게시물이 하나도 없을 경우
         throw new SkillNotFoundException();
       }
-
-      //skillId와 맵핑된 postId List로 반환. 각각 다른 skillId 2개가 한개의 postId를 가리킬 경우.중복 제거
-      allPostIdBySkill = postSkillJpaRepository.findPostIdsBySkillIds(skillIdsBySkillName);
-
     }
     OrderSpecifier<?> orderSpecifier = getOrderSpecifier(pageable);
 
@@ -64,15 +57,9 @@ public class GetAllPostsOfSkillService implements GetAllPostsOfSkillUseCase {
       case "createdAt":
         return new OrderSpecifier<LocalDateTime>(Order.DESC, post.createdAt);
       // 후에 필요할 다른 정렬 조건 추가
+
+      default:
+        throw new UnsupportedSortException();
     }
-
-    throw new UnsupportedSortException();
-  }
-
-  //URL 주소: Java%2CSpring -> Java,Spring -> [Java,Spring]
-  private List<String> splitHashTagsUrl(String skillName) {
-    String[] hashtagArray = skillName.split(",");
-
-    return new ArrayList<>(List.of(hashtagArray));
   }
 }

--- a/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
+++ b/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
@@ -1,0 +1,78 @@
+package com.project.socket.postskill.service;
+
+import static com.project.socket.post.model.QPost.post;
+
+import com.project.socket.post.exception.UnsupportedSortException;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostDto;
+import com.project.socket.postskill.repository.PostSkillJpaRepository;
+import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
+import com.project.socket.skill.exception.SkillNotFoundException;
+import com.project.socket.skill.repository.SkillJpaRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetAllPostsOfSkillService implements GetAllPostsOfSkillUseCase {
+
+  private final PostJpaRepository postJpaRepository;
+  private final SkillJpaRepository skillJpaRepository;
+  private final PostSkillJpaRepository postSkillJpaRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<PostDto> getPostsUsingSkill(String skillName, Pageable pageable) {
+    HashSet<Long> allPostIdBySkill = new HashSet<>();
+
+    if (skillName != null && !skillName.isEmpty()) {
+      List<String> hashTags = splitHashTagsUrl(skillName);
+
+      // strings에 있는 skillName의 Id값 list에 저장
+      List<Long> skillIdsBySkillName = skillJpaRepository.findAllIdBySkillNames(hashTags);
+      if (skillIdsBySkillName.isEmpty()) {
+        throw new SkillNotFoundException();
+      }
+
+      //skillId와 맵핑된 postId List로 반환. 각각 다른 skillId 2개가 한개의 postId를 가리킬 경우.중복 제거
+      allPostIdBySkill = postSkillJpaRepository.findPostIdsBySkillIds(skillIdsBySkillName);
+
+    }
+    OrderSpecifier<?> orderSpecifier = getOrderSpecifier(pageable);
+
+    Page<PostDto> postsByHashTag = postJpaRepository.getPostsByHashTag(allPostIdBySkill, pageable,
+        orderSpecifier);
+
+    return postsByHashTag;
+  }
+
+  private OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
+    Sort sort = pageable.getSort();
+    Sort.Order order = sort.iterator().next(); //첫번째 정렬 조건 가져옴
+
+    switch (order.getProperty()) {
+      case "createdAt":
+        return new OrderSpecifier<LocalDateTime>(Order.DESC, post.createdAt);
+      // 후에 필요할 다른 정렬 조건 추가
+    }
+
+    throw new UnsupportedSortException();
+  }
+
+  //URL 주소: Java%2CSpring -> Java,Spring -> [Java,Spring]
+  private List<String> splitHashTagsUrl(String skillName) {
+    String[] hashtagArray = skillName.split(",");
+
+    return new ArrayList<>(List.of(hashtagArray));
+  }
+}

--- a/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
+++ b/src/main/java/com/project/socket/postskill/service/GetAllPostsOfSkillService.java
@@ -7,7 +7,6 @@ import com.project.socket.post.repository.PostJpaRepository;
 import com.project.socket.post.service.usecase.PostDto;
 import com.project.socket.postskill.repository.PostSkillJpaRepository;
 import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
-import com.project.socket.skill.exception.SkillNotFoundException;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import java.time.LocalDateTime;
@@ -37,8 +36,8 @@ public class GetAllPostsOfSkillService implements GetAllPostsOfSkillUseCase {
       allPostIdBySkill = postSkillJpaRepository.findPostIdsBySkillIds(skillIdList);
 
       if (allPostIdBySkill.isEmpty()) {
-        // 입력받은 해시태그ID와 맵핑된 게시물이 하나도 없을 경우
-        throw new SkillNotFoundException();
+        // 입력받은 해시태그ID와 맵핑된 게시물이 하나도 없을 경우 빈 페이지 반환
+        return Page.empty();
       }
     }
     OrderSpecifier<?> orderSpecifier = getOrderSpecifier(pageable);

--- a/src/main/java/com/project/socket/postskill/service/usecase/GetAllPostsOfSkillUseCase.java
+++ b/src/main/java/com/project/socket/postskill/service/usecase/GetAllPostsOfSkillUseCase.java
@@ -1,10 +1,11 @@
 package com.project.socket.postskill.service.usecase;
 
 import com.project.socket.post.service.usecase.PostDto;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface GetAllPostsOfSkillUseCase {
 
-  Page<PostDto> getPostsUsingSkill(String skillName, Pageable pageable);
+  Page<PostDto> getPostsUsingSkill(List<Long> hashtagIds, Pageable pageable);
 }

--- a/src/main/java/com/project/socket/postskill/service/usecase/GetAllPostsOfSkillUseCase.java
+++ b/src/main/java/com/project/socket/postskill/service/usecase/GetAllPostsOfSkillUseCase.java
@@ -1,0 +1,10 @@
+package com.project.socket.postskill.service.usecase;
+
+import com.project.socket.post.service.usecase.PostDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface GetAllPostsOfSkillUseCase {
+
+  Page<PostDto> getPostsUsingSkill(String skillName, Pageable pageable);
+}

--- a/src/main/java/com/project/socket/skill/exception/SkillNotFoundException.java
+++ b/src/main/java/com/project/socket/skill/exception/SkillNotFoundException.java
@@ -1,0 +1,12 @@
+package com.project.socket.skill.exception;
+
+import static com.project.socket.common.error.ErrorCode.SKILL_NOT_FOUND;
+
+import com.project.socket.common.error.exception.BusinessException;
+
+public class SkillNotFoundException extends BusinessException {
+
+  public SkillNotFoundException() {
+    super(SKILL_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/socket/skill/repository/SkillJpaRepository.java
+++ b/src/main/java/com/project/socket/skill/repository/SkillJpaRepository.java
@@ -1,16 +1,10 @@
 package com.project.socket.skill.repository;
 
 import com.project.socket.skill.model.Skill;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface SkillJpaRepository extends JpaRepository<Skill, Long> {
+public interface SkillJpaRepository extends JpaRepository<Skill, Long>, SkillJpaRepositoryCustom {
 
   Optional<Skill> findBySkillName(String skillName);
-
-  @Query("SELECT s.id from Skill s where s.skillName in :skillNames")
-  List<Long> findAllIdBySkillNames(@Param("skillNames") List<String> skillNames);
 }

--- a/src/main/java/com/project/socket/skill/repository/SkillJpaRepository.java
+++ b/src/main/java/com/project/socket/skill/repository/SkillJpaRepository.java
@@ -1,10 +1,16 @@
 package com.project.socket.skill.repository;
 
 import com.project.socket.skill.model.Skill;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SkillJpaRepository extends JpaRepository<Skill, Long> {
 
   Optional<Skill> findBySkillName(String skillName);
+
+  @Query("SELECT s.id from Skill s where s.skillName in :skillNames")
+  List<Long> findAllIdBySkillNames(@Param("skillNames") List<String> skillNames);
 }

--- a/src/main/java/com/project/socket/skill/repository/SkillJpaRepositoryCustom.java
+++ b/src/main/java/com/project/socket/skill/repository/SkillJpaRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.project.socket.skill.repository;
+
+import java.util.List;
+
+public interface SkillJpaRepositoryCustom {
+
+  List<Long> findAllIdBySkillNames(List<String> skillNames);
+}

--- a/src/main/java/com/project/socket/skill/repository/SkillJpaRepositoryImpl.java
+++ b/src/main/java/com/project/socket/skill/repository/SkillJpaRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.project.socket.skill.repository;
+
+import static com.project.socket.skill.model.QSkill.skill;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class SkillJpaRepositoryImpl implements SkillJpaRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<Long> findAllIdBySkillNames(List<String> skillNames) {
+    return jpaQueryFactory
+        .select(skill.id)
+        .from(skill)
+        .where(skill.skillName.in(skillNames))
+        .fetch();
+  }
+
+}

--- a/src/test/java/com/project/socket/post/controller/dto/response/PagePostResponseDtoTest.java
+++ b/src/test/java/com/project/socket/post/controller/dto/response/PagePostResponseDtoTest.java
@@ -1,0 +1,74 @@
+package com.project.socket.post.controller.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostStatus;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.service.usecase.PostDto;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PagePostResponseDtoTest {
+
+  @Test
+  void 빈_페이지일_경우_빈_리스트와_값이없는_페이징_데이터를_반환한다() {
+
+    Page<PostDto> postDtoPage = new PageImpl<>(Collections.emptyList());
+
+    PagePostResponseDto result = PagePostResponseDto.toResponse(postDtoPage);
+
+    assertAll(
+        () -> assertThat(result.content()).isEmpty(),
+        () -> assertThat(result.pageMetaData().totalElements()).isEqualTo(0),
+        () -> assertThat(result.pageMetaData().sortCriteria()).isEqualTo("")
+    );
+  }
+
+  @Test
+  void 빈_페이지가_아닐경우_게시물과_페이징_데이터를_반환한다() {
+    Pageable pageable = PageRequest.of(0, 3, Sort.Direction.DESC, "createdAt");
+
+    Page<PostDto> postDtoPage = new PageImpl<>(postDtoList(), pageable,
+        postDtoList().size());
+
+    PagePostResponseDto result = PagePostResponseDto.toResponse(postDtoPage);
+
+    assertAll(
+        () -> assertThat(result.content()).isNotEmpty(),
+        () -> assertThat(result.pageMetaData().totalElements()).isEqualTo(5),
+        () -> assertThat(result.pageMetaData().totalPages()).isEqualTo(2),
+        () -> assertThat(result.pageMetaData().sortCriteria()).isEqualTo("createdAt")
+    );
+  }
+
+  List<PostDto> postDtoList() {
+    return List.of(
+        new PostDto(1L, "title1", "content1", PostType.STUDY, PostMeeting.ONLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(2L, "title2", "content2", PostType.PROJECT, PostMeeting.OFFLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(3L, "title3", "content3", PostType.STUDY, PostMeeting.ON_OFFLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(4L, "title4", "content4", PostType.PROJECT, PostMeeting.ONLINE,
+            PostStatus.MODIFIED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(5L, "title5", "content5", PostType.STUDY, PostMeeting.OFFLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now())
+
+    );
+  }
+}

--- a/src/test/java/com/project/socket/post/repository/PostJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/post/repository/PostJpaRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.project.socket.post.repository;
 
 
+import static com.project.socket.post.model.QPost.post;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -11,9 +12,19 @@ import com.project.socket.post.model.PostType;
 import com.project.socket.post.service.usecase.PostDto;
 import com.project.socket.user.model.User;
 import com.project.socket.user.repository.UserJpaRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.jdbc.Sql;
 
 @CustomDataJpaTest
@@ -84,7 +95,40 @@ class PostJpaRepositoryTest {
   @Test
   void postId가_null이면_게시글을_반환한다() {
     Optional<PostDto> postByPostId = postJpaRepository.findPostByPostId(null);
-    
+
     assertThat(postByPostId).isNotEmpty();
+  }
+
+  @Sql("getAllPostsByHashTag.sql")
+  @Test
+  void postId에_해당하는_게시물을_페이징하여_createdAt을_기준_내림차순_으로_반환한다() {
+    HashSet<Long> postIdList = new HashSet<>(List.of(1L, 2L, 3L, 4L, 5L));
+    Pageable pageable = PageRequest.of(0, 2, Sort.Direction.DESC, "createdAt");
+    OrderSpecifier<LocalDateTime> orderSpecifier = new OrderSpecifier<>(Order.DESC, post.createdAt);
+
+    Page<PostDto> postsByHashTag = postJpaRepository.getPostsByHashTag(postIdList, pageable,
+        orderSpecifier);
+
+    assertThat(postsByHashTag.getSize()).isEqualTo(2);
+    assertThat(postsByHashTag.getTotalPages()).isEqualTo(3);
+    assertThat(postsByHashTag).extracting("postId").containsExactly(5L, 4L);
+  }
+
+
+  @Sql("getAllPostsByHashTag.sql")
+  @Test
+  void 입력받는_postId의_HashSet이_빈_컬렉션일_경우_모든_게시물를_페이징하여_반환한다() {
+    HashSet<Long> postIdList = new HashSet<>(Collections.emptyList());
+    Pageable pageable = PageRequest.of(2, 2, Sort.by("createdAt").descending());
+    OrderSpecifier<LocalDateTime> orderSpecifier = new OrderSpecifier<>(Order.DESC, post.createdAt);
+
+    Page<PostDto> postsByHashTag = postJpaRepository.getPostsByHashTag(postIdList, pageable,
+        orderSpecifier);
+
+    assertThat(postsByHashTag.getTotalPages()).isEqualTo(3);
+    assertThat(postsByHashTag.getTotalElements()).isEqualTo(5);
+    assertThat(postsByHashTag).extracting("postId").containsExactly(1L);
+
+
   }
 }

--- a/src/test/java/com/project/socket/postskill/controller/GetAllPostsOfSkillControllerTest.java
+++ b/src/test/java/com/project/socket/postskill/controller/GetAllPostsOfSkillControllerTest.java
@@ -68,7 +68,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(hashTag),
         any(Pageable.class))).thenReturn(postDtoPage);
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", hashTag)
             .param("page", String.valueOf(page))
             .param("order", order))
@@ -134,7 +134,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(null), any(Pageable.class)))
         .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("page", String.valueOf(page))
             .param("order", order))
         .andExpect(status().isOk());
@@ -148,7 +148,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(""), any(Pageable.class)))
         .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", "")
             .param("page", String.valueOf(page))
             .param("order", order))
@@ -157,7 +157,7 @@ class GetAllPostsOfSkillControllerTest {
 
   @Test
   void 페이징의_page_parameter가_0보다_작으면_400_응답을_한다() throws Exception {
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", hashTag)
             .param("page", String.valueOf(-1))
             .param("order", "createdAt"))
@@ -172,7 +172,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class)))
         .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", hashTag)
             .param("page", String.valueOf(page)))
         .andExpect(status().isOk());
@@ -183,7 +183,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class))).thenThrow(
         new UnsupportedSortException());
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", hashTag)
             .param("page", String.valueOf(page))
             .param("order", "wrongOrder"))
@@ -196,7 +196,7 @@ class GetAllPostsOfSkillControllerTest {
     when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class))).thenThrow(
         new SkillNotFoundException());
 
-    mockMvc.perform(get("/posts")
+    mockMvc.perform(get("/posts/projects")
             .param("hashtag", hashTag)
             .param("page", String.valueOf(page))
             .param("order", order))

--- a/src/test/java/com/project/socket/postskill/controller/GetAllPostsOfSkillControllerTest.java
+++ b/src/test/java/com/project/socket/postskill/controller/GetAllPostsOfSkillControllerTest.java
@@ -1,0 +1,223 @@
+package com.project.socket.postskill.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.socket.common.annotation.CustomWebMvcTestWithRestDocs;
+import com.project.socket.docs.DocumentLinkGenerator;
+import com.project.socket.docs.DocumentLinkGenerator.DocUrl;
+import com.project.socket.post.exception.UnsupportedSortException;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostStatus;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.service.usecase.PostDto;
+import com.project.socket.postskill.service.usecase.GetAllPostsOfSkillUseCase;
+import com.project.socket.skill.exception.SkillNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@CustomWebMvcTestWithRestDocs(GetAllPostsOfSkillController.class)
+class GetAllPostsOfSkillControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  GetAllPostsOfSkillUseCase getAllPostsOfSkillUseCase;
+
+  final String hashTag = "Java,Spring";
+  final int page = 0;
+  final int size = 5;
+  final String order = "createdAt";
+
+
+  @Test
+  void 요청이_유효하면_해시태그_페이지_크기에_해당하는_게시물_조회와_200_응답을_한다() throws Exception {
+    List<PostDto> postDtos = samplePostDtos();
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, order);
+    Page<PostDto> postDtoPage = new PageImpl<>(postDtos, pageable, postDtos.size());
+
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(hashTag),
+        any(Pageable.class))).thenReturn(postDtoPage);
+
+    mockMvc.perform(get("/posts")
+            .param("hashtag", hashTag)
+            .param("page", String.valueOf(page))
+            .param("order", order))
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("getAllPostsOfSkill",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                    parameterWithName("hashtag").description("해시 태그"),
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("order").description("정렬 기준")
+                ),
+                responseFields(
+                    // 게시물 정보 필드
+                    fieldWithPath("content[].postId").type(JsonFieldType.NUMBER).description("포스트 ID"),
+                    fieldWithPath("content[].title").type(JsonFieldType.STRING).description("포스트 제목"),
+                    fieldWithPath("content[].postContent").type(JsonFieldType.STRING)
+                        .description("포스트 본문 내용"),
+                    fieldWithPath("content[].postType").description(
+                        DocumentLinkGenerator.generateLinkCode(DocUrl.POST_TYPE)),
+                    fieldWithPath("content[].postMeeting").description(
+                        DocumentLinkGenerator.generateLinkCode(DocUrl.POST_MEETING)),
+                    fieldWithPath("content[].postStatus").description(
+                        DocumentLinkGenerator.generateLinkCode(DocUrl.POST_STATUS)),
+                    fieldWithPath("content[].userId").description("게시물 작성자 ID"),
+                    fieldWithPath("content[].userNickname").description("게시물 작성자 닉네임"),
+                    fieldWithPath("content[].createdAt").type(JsonFieldType.STRING)
+                        .description("게시물 생성일"),
+
+                    fieldWithPath("pageMetaData.totalElements").type(JsonFieldType.NUMBER)
+                        .description("전체 게시물 수"),
+                    fieldWithPath("pageMetaData.totalPages").type(JsonFieldType.NUMBER)
+                        .description("전체 페이지 수"),
+                    fieldWithPath("pageMetaData.pageNumber").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지 번호"),
+                    fieldWithPath("pageMetaData.pageSize").type(JsonFieldType.NUMBER)
+                        .description("페이지당 게시물 수"),
+                    fieldWithPath("pageMetaData.currentPageElements").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지의 게시물 수"),
+                    fieldWithPath("pageMetaData.isFirstPage").type(JsonFieldType.BOOLEAN)
+                        .description("현재 페이지가 첫번째 페이지인지 여부"),
+                    fieldWithPath("pageMetaData.isLastPage").type(JsonFieldType.BOOLEAN)
+                        .description("현재 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("pageMetaData.hasPreviousPage").type(JsonFieldType.BOOLEAN)
+                        .description("이전 페이지가 있는지 여부"),
+                    fieldWithPath("pageMetaData.hasNextPage").type(JsonFieldType.BOOLEAN)
+                        .description("다음 페이지가 있는지 여부"),
+                    fieldWithPath("pageMetaData.sortCriteria").type(JsonFieldType.STRING)
+                        .description("필터링 기준"),
+                    fieldWithPath("pageMetaData.sortDirection").type(JsonFieldType.STRING)
+                        .description("정렬 방향 (ASC-오름차순 / DESC-내림차순)")
+
+                )
+            )
+        );
+  }
+
+  @Test
+  void hashtag_값이_null_이면_200_응답을_한다() throws Exception {
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, order);
+
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(null), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
+
+    mockMvc.perform(get("/posts")
+            .param("page", String.valueOf(page))
+            .param("order", order))
+        .andExpect(status().isOk());
+  }
+
+
+  @Test
+  void hashtag_값이_빈값_이면_200_응답을_한다() throws Exception {
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, order);
+
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(eq(""), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
+
+    mockMvc.perform(get("/posts")
+            .param("hashtag", "")
+            .param("page", String.valueOf(page))
+            .param("order", order))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void 페이징의_page_parameter가_0보다_작으면_400_응답을_한다() throws Exception {
+    mockMvc.perform(get("/posts")
+            .param("hashtag", hashTag)
+            .param("page", String.valueOf(-1))
+            .param("order", "createdAt"))
+        .andExpect(status().isBadRequest());
+
+  }
+
+  @Test
+  void 정렬조건인_order_가_null_일_경우_200_응답을_한다() throws Exception {
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, order);
+
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size()));
+
+    mockMvc.perform(get("/posts")
+            .param("hashtag", hashTag)
+            .param("page", String.valueOf(page)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void 정렬조건인_order_가_정렬기준에_없을경우_UnsupportedSortException_예외가_발생하며_404_응답을_한다() throws Exception {
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class))).thenThrow(
+        new UnsupportedSortException());
+
+    mockMvc.perform(get("/posts")
+            .param("hashtag", hashTag)
+            .param("page", String.valueOf(page))
+            .param("order", "wrongOrder"))
+        .andExpect(status().isBadRequest());
+  }
+
+
+  @Test
+  void skillName의_조회결과가_없어_SkillNotFoundException_예외가_발생하면_404_응답을_한다() throws Exception {
+    when(getAllPostsOfSkillUseCase.getPostsUsingSkill(anyString(), any(Pageable.class))).thenThrow(
+        new SkillNotFoundException());
+
+    mockMvc.perform(get("/posts")
+            .param("hashtag", hashTag)
+            .param("page", String.valueOf(page))
+            .param("order", order))
+        .andExpect(status().isNotFound());
+
+  }
+
+
+  private List<PostDto> samplePostDtos() {
+    return List.of(
+        new PostDto(1L, "title1", "content1", PostType.PROJECT, PostMeeting.ONLINE,
+            PostStatus.DELETED, 1L, "nickname1", LocalDateTime.now()),
+        new PostDto(2L, "title2", "content2", PostType.STUDY, PostMeeting.OFFLINE,
+            PostStatus.CREATED, 1L, "nickname2", LocalDateTime.now()),
+        new PostDto(3L, "title3", "content3", PostType.PROJECT, PostMeeting.OFFLINE,
+            PostStatus.MODIFIED, 1L, "nickname3", LocalDateTime.now()),
+        new PostDto(4L, "title4", "content4", PostType.STUDY, PostMeeting.ONLINE,
+            PostStatus.CREATED, 1L, "nickname4", LocalDateTime.now()),
+        new PostDto(5L, "title5", "content5", PostType.STUDY, PostMeeting.ONLINE,
+            PostStatus.CREATED, 1L, "nickname5", LocalDateTime.now())
+    );
+  }
+
+}

--- a/src/test/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/postskill/repository/PostSkillJpaRepositoryTest.java
@@ -9,6 +9,10 @@ import com.project.socket.post.repository.PostJpaRepository;
 import com.project.socket.postskill.model.PostSkill;
 import com.project.socket.skill.model.Skill;
 import com.project.socket.skill.repository.SkillJpaRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,5 +48,28 @@ class PostSkillJpaRepositoryTest {
         () -> assertThat(savedPostSkill.getPsPost()).isNotNull(),
         () -> assertThat(savedPostSkill.getPsSkill()).isNotNull()
     );
+  }
+
+  @Sql("findAllPostsBySkillName.sql")
+  @Test
+  void skillId에_해당하는_postId를_반환한다() {
+
+    List<Long> skillIds = List.of(1L, 2L);
+
+    HashSet<Long> allPostId = postSkillJpaRepository.findPostIdsBySkillIds(skillIds);
+
+    System.out.println(Arrays.toString(allPostId.toArray()));
+
+    assertThat(allPostId.size()).isEqualTo(2);
+  }
+
+  @Sql("findAllPostsBySkillName.sql")
+  @Test
+  void skillId가_존재하지_않을_경우_빈_HashSet을_반환한다() {
+    List<Long> skillIds = Collections.emptyList();
+
+    HashSet<Long> allPostId = postSkillJpaRepository.findPostIdsBySkillIds(skillIds);
+
+    assertThat(allPostId).isEmpty();
   }
 }

--- a/src/test/java/com/project/socket/postskill/service/GetAllPostsOfSkillServiceTest.java
+++ b/src/test/java/com/project/socket/postskill/service/GetAllPostsOfSkillServiceTest.java
@@ -1,0 +1,164 @@
+package com.project.socket.postskill.service;
+
+import static com.project.socket.post.model.QPost.post;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.post.exception.UnsupportedSortException;
+import com.project.socket.post.model.PostMeeting;
+import com.project.socket.post.model.PostStatus;
+import com.project.socket.post.model.PostType;
+import com.project.socket.post.repository.PostJpaRepository;
+import com.project.socket.post.service.usecase.PostDto;
+import com.project.socket.postskill.repository.PostSkillJpaRepository;
+import com.project.socket.skill.exception.SkillNotFoundException;
+import com.project.socket.skill.repository.SkillJpaRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GetAllPostsOfSkillServiceTest {
+
+  @InjectMocks
+  GetAllPostsOfSkillService getAllPostsOfSkillService;
+
+  @Mock
+  PostJpaRepository postJpaRepository;
+
+  @Mock
+  SkillJpaRepository skillJpaRepository;
+
+  @Mock
+  PostSkillJpaRepository postSkillJpaRepository;
+
+  private final List<String> hashTags = List.of("Java", "Spring");
+  private final List<Long> skillIds = List.of(1L, 2L);
+
+  private int page = 0;
+  private int size = 3;
+
+  Pageable pageable = PageRequest.of(page, size, Direction.DESC, "createdAt");
+  OrderSpecifier<?> orderSpecifier = new OrderSpecifier<>(Order.DESC, post.createdAt);
+  Page<PostDto> expectedPage = new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size());
+
+
+  @Test
+  void skillName과_관련된_게시물이_있으면_성공적으로_조회한다() {
+    String skillName = "Java,Spring";
+    HashSet<Long> allPostIdBySkill = new HashSet<>(List.of(1L, 2L, 3L));
+
+    // Stub
+    when(skillJpaRepository.findAllIdBySkillNames(anyList())).thenReturn(skillIds);
+    when(postSkillJpaRepository.findPostIdsBySkillIds(anyList())).thenReturn(allPostIdBySkill);
+    when(postJpaRepository.getPostsByHashTag(any(), any(Pageable.class), any()))
+        .thenReturn(expectedPage);
+
+    Page<PostDto> actualPosts
+        = getAllPostsOfSkillService.getPostsUsingSkill(skillName, pageable);
+
+    assertThat(expectedPage).isEqualTo(actualPosts);
+    verify(skillJpaRepository, times(1)).findAllIdBySkillNames(hashTags);
+    verify(postSkillJpaRepository, times(1)).findPostIdsBySkillIds(skillIds);
+    verify(postJpaRepository, times(1))
+        .getPostsByHashTag(allPostIdBySkill, pageable, orderSpecifier);
+  }
+
+
+  @Test
+  void skillName이_null_일_경우_모든_게시물을_페이징해서_조회한다() {
+    String skillName = null;
+    HashSet<Long> allPostIdBySkill = new HashSet<>();
+
+    when(postJpaRepository.getPostsByHashTag(any(), any(Pageable.class), any()))
+        .thenReturn(expectedPage);
+
+    Page<PostDto> actualPosts
+        = getAllPostsOfSkillService.getPostsUsingSkill(skillName, pageable);
+
+    assertThat(expectedPage).isEqualTo(actualPosts);
+    verify(skillJpaRepository, times(0)).findAllIdBySkillNames(hashTags);
+    verify(postSkillJpaRepository, times(0)).findPostIdsBySkillIds(skillIds);
+    verify(postJpaRepository, times(1)).getPostsByHashTag(allPostIdBySkill, pageable,
+        orderSpecifier);
+  }
+
+  @Test
+  void skillName이_빈_문자열_일경우_모든_게시물을_페이징해서_조회한다() {
+    String skillName = "";
+    HashSet<Long> allPostIdBySkill = new HashSet<>();
+    Page<PostDto> expectedPage =
+        new PageImpl<>(samplePostDtos(), pageable, samplePostDtos().size());
+
+    when(postJpaRepository.getPostsByHashTag(any(), any(Pageable.class), any()))
+        .thenReturn(expectedPage);
+
+    Page<PostDto> actualPosts
+        = getAllPostsOfSkillService.getPostsUsingSkill(skillName, pageable);
+
+    assertThat(expectedPage).isEqualTo(actualPosts);
+    verify(skillJpaRepository, times(0)).findAllIdBySkillNames(hashTags);
+    verify(postSkillJpaRepository, times(0)).findPostIdsBySkillIds(skillIds);
+    verify(postJpaRepository, times(1)).getPostsByHashTag(allPostIdBySkill, pageable,
+        orderSpecifier);
+  }
+
+  @Test
+  void skillName_조회결과가_없으면_SkillNotFoundException_예외가_발생한다() {
+    String skillName = "Java";
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, "createdAt");
+
+    when(skillJpaRepository.findAllIdBySkillNames(anyList())).thenReturn(List.of());
+
+    assertThatThrownBy(() -> getAllPostsOfSkillService.getPostsUsingSkill(skillName, pageable))
+        .isInstanceOf(SkillNotFoundException.class);
+  }
+
+  @Test
+  void order_정렬기준이_case에_없으면_UnsupportSortException_예외가_발생한다() {
+    String skillName = "Java,Spring";
+    HashSet<Long> postIds = new HashSet<>(List.of(1L, 2L, 3L));
+    Pageable pageable = PageRequest.of(page, size, Direction.DESC, "wrongOrder");
+
+    when(skillJpaRepository.findAllIdBySkillNames(anyList())).thenReturn(skillIds);
+    when(postSkillJpaRepository.findPostIdsBySkillIds(anyList())).thenReturn(postIds);
+
+    assertThatThrownBy(() -> getAllPostsOfSkillService.getPostsUsingSkill(skillName, pageable))
+        .isInstanceOf(UnsupportedSortException.class);
+  }
+
+
+  List<PostDto> samplePostDtos() {
+    return List.of(
+        new PostDto(1L, "title1", "content1", PostType.STUDY, PostMeeting.ONLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(2L, "title2", "content2", PostType.STUDY, PostMeeting.OFFLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now()),
+        new PostDto(3L, "title3", "content3", PostType.STUDY, PostMeeting.OFFLINE,
+            PostStatus.CREATED, 1L, "nickname", LocalDateTime.now())
+
+    );
+  }
+
+}
+

--- a/src/test/java/com/project/socket/skill/repository/SkillJpaRepositoryTest.java
+++ b/src/test/java/com/project/socket/skill/repository/SkillJpaRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.project.socket.common.annotation.CustomDataJpaTest;
 import com.project.socket.skill.model.Skill;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ class SkillJpaRepositoryTest {
 
   @Autowired
   SkillJpaRepository skillJpaRepository;
+  private final List<String> skillNames = List.of("Java", "Spring");
 
   @Test
   @Sql("findBySkillName.sql")
@@ -43,5 +45,21 @@ class SkillJpaRepositoryTest {
         () -> assertThat(savedSkill.getId()).isNotNull(),
         () -> assertThat(savedSkill.getSkillName()).isNotNull()
     );
+  }
+
+  @Test
+  @Sql("findBySkillName.sql")
+  void skillName에_해당하는_skillId를_List로_반환한다() {
+    List<Long> allBySkillName = skillJpaRepository.findAllIdBySkillNames(skillNames);
+
+    assertThat(allBySkillName).hasSize(2);
+  }
+
+
+  @Test
+  void skillName에_해당하는_id가_존재하지_않을_경우_빈_리스트를_반환한다() {
+    List<Long> allBySkillName = skillJpaRepository.findAllIdBySkillNames(skillNames);
+
+    assertThat(allBySkillName).isEmpty();
   }
 }

--- a/src/test/resources/com/project/socket/post/repository/getAllPostsByHashTag.sql
+++ b/src/test/resources/com/project/socket/post/repository/getAllPostsByHashTag.sql
@@ -1,0 +1,20 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title1', 'content1', now(), now(), 'CREATED', 'PROJECT');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (2, 1, 'title2', 'content2', date_add(now(),INTERVAL 1 HOUR), now(), 'MODIFIED', 'PROJECT');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (3, 1, 'title3', 'content3', date_add(now(),INTERVAL 2 HOUR), now(), 'CREATED', 'STUDY');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (4, 1, 'title4', 'content4', date_add(now(),INTERVAL 3 HOUR), now(), 'MODIFIED', 'PROJECT');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (5, 1, 'title5', 'content5', date_add(now(),INTERVAL 4 HOUR), now(), 'CREATED', 'STUDY');
+
+

--- a/src/test/resources/com/project/socket/postskill/repository/findAllPostsBySkillName.sql
+++ b/src/test/resources/com/project/socket/postskill/repository/findAllPostsBySkillName.sql
@@ -1,0 +1,40 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title1', 'content1', now(), now(), 'CREATED', 'PROJECT');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (2, 1, 'title2', 'content2', now(), now(), 'MODIFIED', 'STUDY');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (3, 1, 'title3', 'content3', now(), now(), 'CREATED', 'PROJECT');
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (4, 1, 'title4', 'content4', now(), now(), 'CREATED', 'STUDY');
+
+insert into skill (skill_id, skill_name)
+VALUES (1, 'Java');
+
+insert into skill (skill_id, skill_name)
+VALUES (2, 'Spring');
+
+insert into skill (skill_id, skill_name)
+VALUES (3, 'Python');
+
+insert into post_skill (post_skill_id, post_id, skill_id)
+VALUES (1, 1, 1);
+
+insert into post_skill (post_skill_id, post_id, skill_id)
+VALUES (2, 2, 2);
+
+insert into post_skill (post_skill_id, post_id, skill_id)
+VALUES (3, 3, 3);
+
+insert into post_skill (post_skill_id, post_id, skill_id)
+VALUES (4, 1, 2);
+
+insert into post_skill (post_skill_id, post_id, skill_id)
+VALUES (5, 4, 3);
+

--- a/src/test/resources/com/project/socket/skill/repository/findBySkillName.sql
+++ b/src/test/resources/com/project/socket/skill/repository/findBySkillName.sql
@@ -1,2 +1,8 @@
 insert into skill (skill_id, skill_name)
 VALUES (1, 'Java');
+
+insert into skill (skill_id, skill_name)
+VALUES (2, 'Spring');
+
+insert into skill (skill_id, skill_name)
+VALUES (3, 'Redis');


### PR DESCRIPTION
## PR 요약
[컨트롤러]

1. hashtag 파라미터에 입력값이 null이거나 빈값일 경우 -> page 입력값에 따라 게시물 페이징하여 반환.
    1-1. null 전달 : http://localhost:8080/posts?page=0&order=createdAt
    1-2. 빈값 전달: http://localhost:8080/posts?hashtag=&page=0&order=createdAt 

2. size=10으로 고정, page가 0보다 작을 경우 400 에러 반환.

3. order(정렬기준)의 경우 입력하지 않을 시, 'createdAt'을 기준으로 정렬.
    3-1. 정렬case에 없는 기준 입력받을 경우 400 에러 반환

[비즈니스 로직]

1. skillName(hashtag) 파라미터가 null이거나 빈값 일 경우 
   -> 빈 HashSet 객체가 postJpaRepository의 Querydsl에 전달돼, where절에 null이 들어갑니다. 따라서, 모든 post엔티티가 page 입력값에 맞게 페이징 하여 반환됩니다.

2. 만약 전달받은 hashtag_id가 skill 엔티티에 존재하지 않을 경우, 빈 페이지를 반환합니다. 

3. 'getOrderSpecifier' 메소드의 경우, 어차피 정렬 조건은 한개씩만 들어갈 거라, 'sort.iterator().next()' 를 통해 첫번째 정렬 조건 가져왔습니다.
    2-1. 만약 URL을 통해서 order 파라미터에 case에 없는 정렬기준을 넣을 경우 'UnsupportedSortException' 예외 발생
    2-2. 일단 게시물은 무조건 내림차순 정렬로 하도록 설정했습니다

## 참고 사항
1. post_Id를 저장할 컬렉션을 HashSet으로 사용한 이유는, 만약 Java(skill_Id : 1)와 Spring(skillId : 2) 두개의 hashtag가 모두 post_Id 1과 연관되어있다면 'allPostIdBySkill = postSkillJpaRepository.findAllBySkillId(skillIdsBySkillName)' 이 부분에서 post_id가 중복으로 들어갈 수 있어 HashSet을 사용했습니다.

2. postJpaRepository.getPostsByHashTag의 인자로 (allPostIdBySkill, pageable) 두가지만 넘기려 했는데 
나중에 동적 정렬기준(좋아요순, 등등...)을 사용할까 싶어 OrderSpecifier객체를 사용했습니다.


궁금하시거나 수정할 부분 있으시면 편하게 말씀해주세요!

#### Linked Issue
close `#Issue number`