### PR TITLE
[FEAT] 채팅방 접속시 메시지 전송과 읽음 처리 구현

### DIFF
--- a/src/main/java/com/project/socket/chatmessage/controller/SendEnterMessageController.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/SendEnterMessageController.java
@@ -1,0 +1,29 @@
+package com.project.socket.chatmessage.controller;
+
+import com.project.socket.chatmessage.controller.dto.response.SendEnterMessageResponse;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageCommand;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageUseCase;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@RequiredArgsConstructor
+@Controller
+public class SendEnterMessageController {
+
+  private final SendEnterMessageUseCase sendEnterMessageUseCase;
+  private final SimpMessagingTemplate simpMessagingTemplate;
+
+  @MessageMapping("/enter/{userChatRoomId}")
+  public void sendMessage(@DestinationVariable Long userChatRoomId, Principal principal) {
+    Long userId = Long.valueOf(principal.getName());
+    Long chatRoomId = sendEnterMessageUseCase.apply(
+        new SendEnterMessageCommand(userId, userChatRoomId));
+    SendEnterMessageResponse response = SendEnterMessageResponse.from(userId);
+
+    simpMessagingTemplate.convertAndSend("/sub/rooms/" + chatRoomId, response);
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/controller/dto/response/MessageType.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/dto/response/MessageType.java
@@ -1,0 +1,5 @@
+package com.project.socket.chatmessage.controller.dto.response;
+
+public enum MessageType {
+  ENTER
+}

--- a/src/main/java/com/project/socket/chatmessage/controller/dto/response/SendEnterMessageResponse.java
+++ b/src/main/java/com/project/socket/chatmessage/controller/dto/response/SendEnterMessageResponse.java
@@ -1,0 +1,11 @@
+package com.project.socket.chatmessage.controller.dto.response;
+
+public record SendEnterMessageResponse(
+    MessageType messageType,
+    Long enterId
+) {
+
+  public static SendEnterMessageResponse from(Long userId) {
+    return new SendEnterMessageResponse(MessageType.ENTER, userId);
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.project.socket.chatmessage.repository;
 import com.project.socket.chatmessage.model.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
+    ChatMessageRepositoryCustom {
 
 }

--- a/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.project.socket.chatmessage.repository;
+
+public interface ChatMessageRepositoryCustom {
+
+  long updateAllUnreadMessages(Long chatRoomId, Long userId);
+}

--- a/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.project.socket.chatmessage.repository;
+
+import static com.project.socket.chatmessage.model.QChatMessage.chatMessage;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public long updateAllUnreadMessages(Long chatRoomId, Long userId) {
+    return jpaQueryFactory.update(chatMessage)
+                          .set(chatMessage.readCount, 0)
+                          .where(chatMessage.chatRoom.chatRoomId.eq(chatRoomId).and(
+                              chatMessage.sender.userId.ne(userId)))
+                          .execute();
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/service/SendEnterMessageService.java
+++ b/src/main/java/com/project/socket/chatmessage/service/SendEnterMessageService.java
@@ -1,0 +1,42 @@
+package com.project.socket.chatmessage.service;
+
+import com.project.socket.chatmessage.repository.ChatMessageRepository;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageCommand;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageUseCase;
+import com.project.socket.userchatroom.exception.UserChatRoomNotFoundException;
+import com.project.socket.userchatroom.exception.UserChatRoomNotSameUserException;
+import com.project.socket.userchatroom.model.UserChatRoom;
+import com.project.socket.userchatroom.repository.UserChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SendEnterMessageService implements SendEnterMessageUseCase {
+
+  private final UserChatRoomRepository userChatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+
+  @Transactional
+  @Override
+  public Long apply(SendEnterMessageCommand command) {
+    UserChatRoom userChatRoom = findUserChatRoom(command.userChatRoomId());
+
+    // 잘못된 요청일 경우 예외 발생
+    if (!userChatRoom.isSameUser(command.userId())) {
+      throw new UserChatRoomNotSameUserException();
+    }
+    // 채팅방에 입장하면 UserChatRoom, ChatMessage 의 unreadCount 0으로 감소
+    userChatRoom.enter();
+    Long chatRoomId = userChatRoom.getChatRoom().getChatRoomId();
+    chatMessageRepository.updateAllUnreadMessages(chatRoomId, command.userId());
+
+    return chatRoomId;
+  }
+
+  private UserChatRoom findUserChatRoom(Long userChatRoomId) {
+    return userChatRoomRepository.findById(userChatRoomId)
+                                 .orElseThrow(UserChatRoomNotFoundException::new);
+  }
+}

--- a/src/main/java/com/project/socket/chatmessage/service/usecase/SendEnterMessageCommand.java
+++ b/src/main/java/com/project/socket/chatmessage/service/usecase/SendEnterMessageCommand.java
@@ -1,0 +1,8 @@
+package com.project.socket.chatmessage.service.usecase;
+
+public record SendEnterMessageCommand(
+    Long userId,
+    Long userChatRoomId
+) {
+
+}

--- a/src/main/java/com/project/socket/chatmessage/service/usecase/SendEnterMessageUseCase.java
+++ b/src/main/java/com/project/socket/chatmessage/service/usecase/SendEnterMessageUseCase.java
@@ -1,0 +1,7 @@
+package com.project.socket.chatmessage.service.usecase;
+
+import java.util.function.Function;
+
+public interface SendEnterMessageUseCase extends Function<SendEnterMessageCommand, Long> {
+
+}

--- a/src/main/java/com/project/socket/common/error/ErrorCode.java
+++ b/src/main/java/com/project/socket/common/error/ErrorCode.java
@@ -30,10 +30,15 @@ public enum ErrorCode {
    * ChatRoom 관련 에러 코드
    */
   WRITER_CAN_NOT_START_CHAT(400, "CR1", "작성자는 채팅방을 생성할 수 없습니다"),
-  CHAT_ROOM_NOT_FOUND(404, "CR2", "해당 채팅방이 존재하지 않습니다");
+  CHAT_ROOM_NOT_FOUND(404, "CR2", "해당 채팅방이 존재하지 않습니다"),
 
+  /**
+   * UserChatRoom
+   */
+  USER_CHAT_ROOM_NOT_FOUND(404, "UCR1", "해당 유저 채팅방이 존재하지 않습니다"),
+  USER_CHAT_ROOM_NOT_SAME_USER(400, "UC2", "잘못된 요청입니다.");
 
-  private int status;
+  private final int status;
   private final String code;
   private final String message;
 

--- a/src/main/java/com/project/socket/userchatroom/exception/UserChatRoomNotFoundException.java
+++ b/src/main/java/com/project/socket/userchatroom/exception/UserChatRoomNotFoundException.java
@@ -1,0 +1,11 @@
+package com.project.socket.userchatroom.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class UserChatRoomNotFoundException extends BusinessException {
+
+  public UserChatRoomNotFoundException() {
+    super(ErrorCode.USER_CHAT_ROOM_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/project/socket/userchatroom/exception/UserChatRoomNotSameUserException.java
+++ b/src/main/java/com/project/socket/userchatroom/exception/UserChatRoomNotSameUserException.java
@@ -1,0 +1,11 @@
+package com.project.socket.userchatroom.exception;
+
+import com.project.socket.common.error.ErrorCode;
+import com.project.socket.common.error.exception.BusinessException;
+
+public class UserChatRoomNotSameUserException extends BusinessException {
+
+  public UserChatRoomNotSameUserException() {
+    super(ErrorCode.USER_CHAT_ROOM_NOT_SAME_USER);
+  }
+}

--- a/src/main/java/com/project/socket/userchatroom/model/UserChatRoom.java
+++ b/src/main/java/com/project/socket/userchatroom/model/UserChatRoom.java
@@ -46,6 +46,12 @@ public class UserChatRoom {
     if (isExit()) {
       this.userChatRoomStatus = UserChatRoomStatus.ENTER;
     }
+
+    unreadCount = 0;
+  }
+
+  public boolean isSameUser(Long userId) {
+    return this.user.getUserId().equals(userId);
   }
 
   public boolean isExit() {

--- a/src/test/java/com/project/socket/chatmessage/controller/MessageFrameHandler.java
+++ b/src/test/java/com/project/socket/chatmessage/controller/MessageFrameHandler.java
@@ -1,0 +1,29 @@
+package com.project.socket.chatmessage.controller;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+
+public class MessageFrameHandler<T> implements StompFrameHandler {
+
+  @Getter
+  private final CompletableFuture<T> completableFuture = new CompletableFuture<>();
+
+  private final Class<T> tClass;
+
+  public MessageFrameHandler(Class<T> tClass) {
+    this.tClass = tClass;
+  }
+
+  @Override
+  public Type getPayloadType(StompHeaders headers) {
+    return tClass;
+  }
+
+  @Override
+  public void handleFrame(StompHeaders headers, Object payload) {
+    completableFuture.complete((T) payload);
+  }
+}

--- a/src/test/java/com/project/socket/chatmessage/controller/SendEnterMessageControllerTest.java
+++ b/src/test/java/com/project/socket/chatmessage/controller/SendEnterMessageControllerTest.java
@@ -5,17 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.project.socket.chatmessage.controller.dto.request.SendChatMessageRequest;
-import com.project.socket.chatmessage.model.ChatMessage;
-import com.project.socket.chatmessage.service.usecase.SendChatMessageUseCase;
-import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.chatmessage.controller.dto.response.MessageType;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageUseCase;
 import com.project.socket.config.ContainerBaseTest;
 import com.project.socket.security.JwtProvider;
 import com.project.socket.user.model.Role;
 import com.project.socket.user.model.User;
-import java.lang.reflect.Field;
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -38,15 +34,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class SendChatMessageControllerTest extends ContainerBaseTest {
+class SendEnterMessageControllerTest extends ContainerBaseTest {
 
   @LocalServerPort
   private int port;
   private String URL;
   private WebSocketStompClient stompClient;
   @MockBean
-  private SendChatMessageUseCase sendChatMessageUseCase;
-  final String SEND_MESSAGE_ENDPOINT = "/pub/rooms/";
+  private SendEnterMessageUseCase sendEnterMessageUseCase;
+  final String SEND_MESSAGE_ENDPOINT = "/pub/enter/";
   final String SUBSCRIBE_CHAT_ROOM_ENDPOINT = "/sub/rooms/";
 
   @Autowired
@@ -60,7 +56,7 @@ class SendChatMessageControllerTest extends ContainerBaseTest {
   }
 
   @Test
-  void 메세지를_발행하면_endpoint를_구독하는_클라이언트에게_전송된다() throws Exception {
+  void 채팅방_입장_메시지가_해당_채팅방을_구독하는_클라이언트에게_전송된다() throws Exception {
     final Long ROOM_ID = 1L;
     StompHeaders connectionHeaders = createConnectionHeaders();
     URI uri = UriComponentsBuilder.fromUriString(URL).buildAndExpand(List.of()).encode().toUri();
@@ -68,23 +64,20 @@ class SendChatMessageControllerTest extends ContainerBaseTest {
     StompSession stompSession = stompClient.connectAsync(uri, null, connectionHeaders,
         new StompSessionHandlerAdapter() {
         }).get(5, SECONDS);
-
     MessageFrameHandler<byte[]> handler = new MessageFrameHandler<>(
         byte[].class);
-    ChatMessage givenMessage = createChatMessage();
 
-    when(sendChatMessageUseCase.sendChatMessage(any())).thenReturn(givenMessage);
+    when(sendEnterMessageUseCase.apply(any())).thenReturn(ROOM_ID);
 
     stompSession.subscribe(SUBSCRIBE_CHAT_ROOM_ENDPOINT + ROOM_ID, handler);
-    stompSession.send(SEND_MESSAGE_ENDPOINT + ROOM_ID, new SendChatMessageRequest(2L, 1L, "hi"));
+    stompSession.send(SEND_MESSAGE_ENDPOINT + ROOM_ID, null);
 
     byte[] chatMessageByte = handler.getCompletableFuture().get(10, SECONDS);
     String json = new String(chatMessageByte);
-
     stompSession.disconnect();
-    assertThat(json).contains("hi");
-  }
 
+    assertThat(json).contains(MessageType.ENTER.name());
+  }
 
   StompHeaders createConnectionHeaders() {
     User user = User.builder().userId(1L).role(Role.ROLE_USER).build();
@@ -92,17 +85,5 @@ class SendChatMessageControllerTest extends ContainerBaseTest {
     StompHeaders stompHeaders = new StompHeaders();
     stompHeaders.set("Authorization", accessToken);
     return stompHeaders;
-  }
-
-  ChatMessage createChatMessage() throws Exception {
-    ChatMessage givenMessage = ChatMessage.builder().chatMessageId(1L).readCount(1).content("hi")
-                                          .chatRoom(ChatRoom.builder().chatRoomId(1L).build())
-                                          .sender(
-                                              User.builder().userId(1L).build()).build();
-
-    Field createdAtField = givenMessage.getClass().getSuperclass().getDeclaredField("createdAt");
-    createdAtField.setAccessible(true);
-    createdAtField.set(givenMessage, LocalDateTime.now());
-    return givenMessage;
   }
 }

--- a/src/test/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/project/socket/chatmessage/repository/ChatMessageRepositoryTest.java
@@ -18,13 +18,21 @@ class ChatMessageRepositoryTest {
 
   @Test
   @Sql("chatMessageTest.sql")
-  void ChatMessage_엔티티를_저장하고_반환한다(){
+  void ChatMessage_엔티티를_저장하고_반환한다() {
     ChatMessage chatMessage = ChatMessage.builder().sender(User.builder().userId(1L).build())
-                                .chatRoom(ChatRoom.builder().chatRoomId(1L).build()).content("hi")
-                                .build();
+                                         .chatRoom(ChatRoom.builder().chatRoomId(1L).build())
+                                         .content("hi")
+                                         .build();
 
     ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
     assertThat(savedChatMessage.getChatMessageId()).isNotNull();
+  }
+
+  @Test
+  @Sql("updateAllUnreadMessages.sql")
+  void 조건에_해당하는_메시지들의_안읽음_카운트를_감소시킨다() {
+    long count = chatMessageRepository.updateAllUnreadMessages(1L, 2L);
+    assertThat(count).isEqualTo(3L);
   }
 }

--- a/src/test/java/com/project/socket/chatmessage/service/SendEnterMessageServiceTest.java
+++ b/src/test/java/com/project/socket/chatmessage/service/SendEnterMessageServiceTest.java
@@ -1,0 +1,82 @@
+package com.project.socket.chatmessage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.project.socket.chatmessage.repository.ChatMessageRepository;
+import com.project.socket.chatmessage.service.usecase.SendEnterMessageCommand;
+import com.project.socket.chatroom.model.ChatRoom;
+import com.project.socket.user.model.User;
+import com.project.socket.userchatroom.exception.UserChatRoomNotFoundException;
+import com.project.socket.userchatroom.exception.UserChatRoomNotSameUserException;
+import com.project.socket.userchatroom.model.UserChatRoom;
+import com.project.socket.userchatroom.model.UserChatRoomStatus;
+import com.project.socket.userchatroom.repository.UserChatRoomRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SendEnterMessageServiceTest {
+
+  @Mock
+  UserChatRoomRepository userChatRoomRepository;
+
+  @Mock
+  ChatMessageRepository chatMessageRepository;
+
+  @InjectMocks
+  SendEnterMessageService sendEnterMessageService;
+
+  SendEnterMessageCommand command = new SendEnterMessageCommand(1L, 1L);
+
+  @Test
+  void userChatRoom이_존재하지_않으면_UserChatRoomNotFoundException_예외가_발생한다() {
+    when(userChatRoomRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> sendEnterMessageService.apply(command))
+        .isInstanceOf(UserChatRoomNotFoundException.class);
+  }
+
+  @Test
+  void 요청차_ID와_일치하지_않으면_UserChatRoomNotSameUserException_예외가_발생한다() {
+    UserChatRoom userChatRoom = UserChatRoom.builder()
+                                            .userChatRoomId(1L)
+                                            .user(User.builder().userId(2L).build())
+                                            .build();
+    when(userChatRoomRepository.findById(anyLong())).thenReturn(Optional.of(userChatRoom));
+
+    assertThatThrownBy(() -> sendEnterMessageService.apply(command))
+        .isInstanceOf(UserChatRoomNotSameUserException.class);
+  }
+
+  @Test
+  void UserChatRoom의_안읽음_개수를_0으로_변경한다() {
+    UserChatRoom userChatRoom = UserChatRoom.builder()
+                                            .userChatRoomId(1L)
+                                            .user(User.builder().userId(1L).build())
+                                            .chatRoom(ChatRoom.builder().chatRoomId(1L).build())
+                                            .unreadCount((short) 10)
+                                            .userChatRoomStatus(UserChatRoomStatus.ENTER)
+                                            .build();
+
+    when(userChatRoomRepository.findById(anyLong())).thenReturn(Optional.of(userChatRoom));
+    when(chatMessageRepository.updateAllUnreadMessages(anyLong(), anyLong())).thenReturn(1L);
+
+    Long chatRoomId = sendEnterMessageService.apply(command);
+
+    assertAll(
+        () -> assertThat(userChatRoom.getUnreadCount()).isEqualTo((short) 0),
+        () -> assertThat(chatRoomId).isEqualTo(userChatRoom.getChatRoom().getChatRoomId())
+    );
+  }
+}

--- a/src/test/java/com/project/socket/userchatroom/model/UserChatRoomTest.java
+++ b/src/test/java/com/project/socket/userchatroom/model/UserChatRoomTest.java
@@ -2,6 +2,7 @@ package com.project.socket.userchatroom.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.project.socket.user.model.User;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,32 @@ import org.junit.jupiter.api.Test;
 class UserChatRoomTest {
 
   @Test
-  void 엔티티_빌더_테스트(){
+  void 엔티티_빌더_테스트() {
     UserChatRoom userChatroom = UserChatRoom.builder().userChatRoomId(1L).build();
     assertThat(userChatroom.getUserChatRoomId()).isEqualTo(1L);
+  }
+
+  @Test
+  void userId가_같으면_true를_반환한다() {
+    UserChatRoom userChatroom = UserChatRoom.builder()
+                                            .userChatRoomId(1L)
+                                            .user(User.builder().userId(1L).build())
+                                            .build();
+
+    boolean result = userChatroom.isSameUser(1L);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void userId가_다르면_false를_반환한다() {
+    UserChatRoom userChatroom = UserChatRoom.builder()
+                                            .userChatRoomId(1L)
+                                            .user(User.builder().userId(1L).build())
+                                            .build();
+
+    boolean result = userChatroom.isSameUser(2L);
+
+    assertThat(result).isFalse();
   }
 }

--- a/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
+++ b/src/test/java/com/project/socket/userchatroom/repository/UserChatRoomRepositoryTest.java
@@ -7,6 +7,8 @@ import com.project.socket.common.annotation.CustomDataJpaTest;
 import com.project.socket.user.model.User;
 import com.project.socket.userchatroom.model.UserChatRoom;
 import com.project.socket.userchatroom.model.UserChatRoomStatus;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
@@ -16,6 +18,9 @@ class UserChatRoomRepositoryTest {
 
   @Autowired
   UserChatRoomRepository userChatRoomRepository;
+
+  @Autowired
+  EntityManager em;
 
   @Test
   @Sql("saveUserChatRoom.sql")
@@ -45,11 +50,41 @@ class UserChatRoomRepositoryTest {
 
   @Test
   @Sql("updateUnreadCount.sql")
-  void 안읽음_개수를_증가시킨다 () {
+  void 안읽음_개수를_증가시킨다() {
     userChatRoomRepository.updateUnreadCount(1L, 1L);
 
     UserChatRoom userChatRoom = userChatRoomRepository.findById(1L).get();
     short expect = 1;
     assertThat(userChatRoom.getUnreadCount()).isEqualTo(expect);
+  }
+
+  @Test
+  @Sql("findByUserChatRoomId.sql")
+  void userChatRoomId_에_해당하는_데이터를_반환한다() {
+    Optional<UserChatRoom> userChatRoom = userChatRoomRepository.findById(1L);
+
+    assertThat(userChatRoom).isPresent();
+  }
+
+  @Test
+  @Sql("findByUserChatRoomId.sql")
+  void userChatRoomId_에_해당하는_데이터가_없으면_빈_Optional을_반환한다() {
+    Optional<UserChatRoom> userChatRoom = userChatRoomRepository.findById(2L);
+
+    assertThat(userChatRoom).isNotPresent();
+  }
+
+  @Test
+  @Sql("updateUnreadCountToZero.sql")
+  void 안읽음_개수를_0으로_변경한다() {
+    UserChatRoom userChatRoom = userChatRoomRepository.findById(1L).get();
+    userChatRoom.enter();
+    em.flush();
+    em.clear();
+
+    UserChatRoom updatedUserChatRoom = userChatRoomRepository.findById(1L).get();
+
+    short expect = 0;
+    assertThat(updatedUserChatRoom.getUnreadCount()).isEqualTo(expect);
   }
 }

--- a/src/test/resources/com/project/socket/chatmessage/repository/updateAllUnreadMessages.sql
+++ b/src/test/resources/com/project/socket/chatmessage/repository/updateAllUnreadMessages.sql
@@ -1,0 +1,37 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (2, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into chat_room(chat_room_id, post_id)
+values (1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id)
+values (1, 1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id)
+values (2, 2, 1);
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (1, 1, 2, 'hi', 1, now());
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (2, 1, 2, 'hi', 1, now());
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (3, 1, 2, 'hi', 1, now());
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (4, 1, 1, 'hi', 1, now());
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (5, 1, 1, 'hi', 1, now());
+
+insert into chat_message(chat_message_id, chat_room_id, sender_id, content, read_count, created_at)
+values (6, 1, 1, 'hi', 1, now());

--- a/src/test/resources/com/project/socket/userchatroom/repository/findByUserChatRoomId.sql
+++ b/src/test/resources/com/project/socket/userchatroom/repository/findByUserChatRoomId.sql
@@ -1,0 +1,16 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (2, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into chat_room(chat_room_id, post_id)
+values (1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id)
+values (1, 1, 1);

--- a/src/test/resources/com/project/socket/userchatroom/repository/updateUnreadCountToZero.sql
+++ b/src/test/resources/com/project/socket/userchatroom/repository/updateUnreadCountToZero.sql
@@ -1,0 +1,16 @@
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (1, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into user (user_id, nickname, social_id, social_provider, role, profile_setup, created_at,
+                  modified_at)
+values (2, 'nickname', '1234', 'GOOGLE', 'ROLE_USER', false, now(), now());
+
+insert into post (post_id, user_id, title, content, created_at, modified_at, post_status, post_type)
+VALUES (1, 1, 'title', 'content', now(), now(), 'CREATED', 'PROJECT');
+
+insert into chat_room(chat_room_id, post_id)
+values (1, 1);
+
+insert into user_chat_room(user_chat_room_id, user_id, chat_room_id, unread_count)
+values (1, 1, 1, 1);


### PR DESCRIPTION
## PR 요약
채팅방 접속시 읽음 처리를 하고 구독자에게 메시지 전송 기능을 구현했습니다.
1. 채팅방 목록에서 채팅방 입장시 `/pub/enter/{userChatRoomId}` pub
2. websocket 연결 유저와 해당 userChatRoomId 에 해당하는 유저가 같은지 판단
3. userChatRoom 안읽음 카운트 -> 0,  chatRoomId에 해당하는 상대방이 보낸 모든 chatMessage 안읽음 카운트 -> 0
4. `/sub/rooms/{chatRoomId}` 해당 경로를 구독하는 클라이언트에게 메시지 전송 ex) 상대방이 해당 채팅방에 접속중이라면 상대방에게 자신이 접속했다는 메시지가 전송.


#### Linked Issue
close #84 